### PR TITLE
docs: fix broken partition router sample and typos across docs

### DIFF
--- a/docker-images/README.md
+++ b/docker-images/README.md
@@ -40,7 +40,7 @@ The `test-base-image-build.sh` script can be used to build the base image.
 ./test-base-image-build.sh java
 ./test-base-image-build.sh java dev
 
-# These are identical, building the pyhton base image with the 'dev' tag:
+# These are identical, building the python base image with the 'dev' tag:
 ./test-base-image-build.sh python
 ./test-base-image-build.sh python dev
 ```

--- a/docs/community/contributing-to-airbyte/resources/pull-requests-handbook.md
+++ b/docs/community/contributing-to-airbyte/resources/pull-requests-handbook.md
@@ -4,7 +4,7 @@ This topic explains how to title and describe your pull requests, and how to han
 
 ## Pull request title conventions
 
-When creating a pull request, follow the naming conventions depending on the change you're making. In general, the pull request title starts with an emoji, the the connector name, then the changes. For example: ✨ Source E-Commerce: add new stream `Users`.
+When creating a pull request, follow the naming conventions depending on the change you're making. In general, the pull request title starts with an emoji, the connector name, then the changes. For example: ✨ Source E-Commerce: add new stream `Users`.
 
 Airbyte uses this pattern to automatically assign team reviews and build the product release notes.
 

--- a/docs/integrations/custom-connectors.md
+++ b/docs/integrations/custom-connectors.md
@@ -40,7 +40,7 @@ See the following guides for more information on building custom Airbyte Docker 
 
 Follow these steps to upgrade a connector version.
 
-1. In the navigaton bar, click **Workspace settings** > **Sources**/**Destinations**.
+1. In the navigation bar, click **Workspace settings** > **Sources**/**Destinations**.
 
 2. Find your connector in the list and click the edit button <svg fill="none" data-icon="pencil" role="img" viewBox="0 0 24 24" class="inline-svg"><path fill="currentColor" d="M22 7.24a1 1 0 0 0-.29-.71l-4.24-4.24a1 1 0 0 0-.71-.29 1 1 0 0 0-.71.29l-2.83 2.83L2.29 16.05a1 1 0 0 0-.29.71V21a1 1 0 0 0 1 1h4.24a1 1 0 0 0 .76-.29l10.87-10.93L21.71 8q.138-.146.22-.33.015-.12 0-.24a.7.7 0 0 0 0-.14zM6.83 20H4v-2.83l9.93-9.93 2.83 2.83zM18.17 8.66l-2.83-2.83 1.42-1.41 2.82 2.82z"></path></svg>.
 

--- a/docs/integrations/destinations/kinesis.md
+++ b/docs/integrations/destinations/kinesis.md
@@ -8,7 +8,7 @@
 
 ### Output schema
 
-The incoming Airbyte data is structured in a Json format and is sent across diferent stream shards determined by the partition key.
+The incoming Airbyte data is structured in a Json format and is sent across different stream shards determined by the partition key.
 This connector maps an incoming data from a namespace and stream to a unique Kinesis stream. The Kinesis record which is sent to the stream is consisted of the following Json fields
 
 - `_airbyte_ab_id`: Random UUID generated to be used as a partition key for sending data to different shards.

--- a/docs/integrations/destinations/yellowbrick.md
+++ b/docs/integrations/destinations/yellowbrick.md
@@ -187,7 +187,7 @@ Each table will contain 3 columns:
 
 ## Tutorials
 
-- Comming soon.
+- Coming soon.
 
 ## Namespace support
 

--- a/docs/integrations/enterprise-connectors/source-sap-hana.md
+++ b/docs/integrations/enterprise-connectors/source-sap-hana.md
@@ -90,7 +90,7 @@ To use CDC:
 - **Database permissions**: Your SAP HANA user must have permissions to:
   - Read from trigger tables in the `_ab_cdc` schema
   - Access source tables for initial discovery
-- **Trigger table setup**: Trigger tables can be created manually or programatically by an administrator of the SAP HANA instance. The setup requires:
+- **Trigger table setup**: Trigger tables can be created manually or programmatically by an administrator of the SAP HANA instance. The setup requires:
   - Create the `_ab_cdc` schema
   - Create trigger tables with the naming convention `_ab_trigger_{source_schema}_{source_table}`
   - Set up INSERT, UPDATE, and DELETE triggers on source tables to populate trigger tables

--- a/docs/integrations/sources/amazon-sqs-migrations.md
+++ b/docs/integrations/sources/amazon-sqs-migrations.md
@@ -2,7 +2,7 @@
 
 ## Upgrading to 1.0.0
 
-The verison migrates the Amazon SQS connector to the low-code framework for greater maintainability. 
+The version migrates the Amazon SQS connector to the low-code framework for greater maintainability. 
 
 Changes regarding configuration of specs:
 - `access_key`, `secret_key`, `queue_url`, `region`, `target` are required for this connector to work

--- a/docs/integrations/sources/amazon-sqs.md
+++ b/docs/integrations/sources/amazon-sqs.md
@@ -65,7 +65,7 @@ Required properties are 'Queue URL', 'AWS Region' and 'Delete Messages After Rea
   - Minimum of 1, maximum of 10
   - Default: 10
 - Max Wait Time (INTEGER)
-  - The max amount of time (in seconds) to poll for messages before commiting a batch (or timing
+  - The max amount of time (in seconds) to poll for messages before committing a batch (or timing
     out) unless we fill a batch (as per `Max Batch Size`)
   - Minimum of 1, maximum of 20
   - Default: 20

--- a/docs/integrations/sources/aws-cloudtrail-migrations.md
+++ b/docs/integrations/sources/aws-cloudtrail-migrations.md
@@ -1,7 +1,7 @@
 # Aws Cloudtrail Migration Guide
 
 ## Upgrading to 1.0.0
-The verison migrates the Aws Cloudtrail connector to the low-code framework for greater maintainability. 
+The version migrates the Aws Cloudtrail connector to the low-code framework for greater maintainability. 
 Important update: The management_events stream changed it's EventTime field from integer to float. Destination should adapt this change if applicable.
 The connector as default uses us-east-1 region for accessing streams with its custom request signer.
 You may need to refresh the connection schema (with the reset), and run a sync.

--- a/docs/integrations/sources/box-data-extract.md
+++ b/docs/integrations/sources/box-data-extract.md
@@ -26,7 +26,7 @@ Decide on what account is going to login to Box:
 - `Box Subject Type`: Represents the type of user to login as ("user" or "enterprise"). Enterprise will login with the application service account. User will login with the user if app can impersonate users.
 - `Box Subject ID`: If subject type is "enterprise", use your enterprise ID If subject type is "user", use the user id to login as.
 
-Choose the which Box folder contains the files you want to process:
+Choose which Box folder contains the files you want to process:
 - `Folder ID`: Folder to retrieve data from.
 - `Recursive`: Read the folders recursively.
 

--- a/docs/integrations/sources/box-data-extract.md
+++ b/docs/integrations/sources/box-data-extract.md
@@ -26,8 +26,8 @@ Decide on what account is going to login to Box:
 - `Box Subject Type`: Represents the type of user to login as ("user" or "enterprise"). Enterprise will login with the application service account. User will login with the user if app can impersonate users.
 - `Box Subject ID`: If subject type is "enterprise", use your enterprise ID If subject type is "user", use the user id to login as.
 
-Choose the which Box folder conatins the files you want to process:
-- `Folder ID`: Folder to retreive data from.
+Choose the which Box folder contains the files you want to process:
+- `Folder ID`: Folder to retrieve data from.
 - `Recursive`: Read the folders recursively.
 
 If you are using Box AI you'll need:

--- a/docs/integrations/sources/copper.md
+++ b/docs/integrations/sources/copper.md
@@ -35,7 +35,7 @@ The Copper source connector supports the following [sync modes](https://docs.air
 - [People](https://developer.copper.com/people/list-people-search.html)
 - [Companies](https://developer.copper.com/companies/list-companies-search.html)
 - [Projects](https://developer.copper.com/projects/list-projects-search.html)
-- [Oppurtunities](https://developer.copper.com/opportunities/list-opportunities-search.html)
+- [Opportunities](https://developer.copper.com/opportunities/list-opportunities-search.html)
 
 ## IP allow list
 

--- a/docs/integrations/sources/dolibarr.md
+++ b/docs/integrations/sources/dolibarr.md
@@ -4,7 +4,7 @@ Connector for the Dolibarr ERP/CRM REST API focused on GET operations
 
 ## Pre-requisites
 - A Dolibarr Installation in Cloud SaaS, On-premises, Web Hosting or cPanel Server.
-- Identify your public Dolibarr URL that will be required to configure the conector.
+- Identify your public Dolibarr URL that will be required to configure the connector.
 - Configure your company data in the Setup menu - Configure your company/organization: [Dolibarr documentation Wiki](https://wiki.dolibarr.org/index.php?title=First_setup#Company.2FOrganization)
 - In the module setup menu enable the Module Web Services API REST (developer) and configure it.
 - Enable the ERP/CRM modules of Dolibarr from you want to GET data with the REST API end points

--- a/docs/integrations/sources/file.md
+++ b/docs/integrations/sources/file.md
@@ -112,7 +112,7 @@ This is the globally unique name of the storage account that the desired blob si
 
 - `Host` (Required)
 
-Enter the _hostname_ or _IP address_ of the remote server where the file trasfer will take place.
+Enter the _hostname_ or _IP address_ of the remote server where the file transfer will take place.
 
 - `User` (Required)
 

--- a/docs/integrations/sources/firebase-realtime-database.md
+++ b/docs/integrations/sources/firebase-realtime-database.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Firebase Realtime Database source supports Full Refresh sync. As the database data is stored as JSON objects and there are no records or tables, you can sync only one stream which you specifed as a JSON node path on your database at a time.
+The Firebase Realtime Database source supports Full Refresh sync. As the database data is stored as JSON objects and there are no records or tables, you can sync only one stream which you specified as a JSON node path on your database at a time.
 
 ### Resulting schema
 

--- a/docs/integrations/sources/firebolt.md
+++ b/docs/integrations/sources/firebolt.md
@@ -4,7 +4,7 @@
 
 The Firebolt source allows you to sync your data from [Firebolt](https://www.firebolt.io/). Only Full refresh is supported at the moment.
 
-The connector is built on top of a pure Python [firebolt-sdk](https://pypi.org/project/firebolt-sdk/) and does not require additonal dependencies.
+The connector is built on top of a pure Python [firebolt-sdk](https://pypi.org/project/firebolt-sdk/) and does not require additional dependencies.
 
 #### Resulting schema
 

--- a/docs/integrations/sources/genesys.md
+++ b/docs/integrations/sources/genesys.md
@@ -21,7 +21,7 @@ You can follow the documentation on [API credentials](https://developer.genesys.
 - [Locations](https://developer.genesys.cloud/telephony/locations-apis)
 - [Routing](https://developer.genesys.cloud/routing/routing/)
 - [Stations](https://developer.genesys.cloud/telephony/stations-apis)
-- [Telephony](hhttps://developer.genesys.cloud/telephony/telephony-apis)
+- [Telephony](https://developer.genesys.cloud/telephony/telephony-apis)
 - [Users](https://developer.genesys.cloud/useragentman/users/)
 
 ## IP allow list

--- a/docs/integrations/sources/glassfrog.md
+++ b/docs/integrations/sources/glassfrog.md
@@ -40,7 +40,7 @@ This Source is capable of syncing the following Streams:
 
 1. Sign in at `app.glassfrog.com`.
 2. Go to `Profile & Settings`.
-3. In the API tab, enter the label for your new API key (e.g. `Airbyte`) and clik on the button `Create new API Key`.
+3. In the API tab, enter the label for your new API key (e.g. `Airbyte`) and click on the button `Create new API Key`.
 4. Use the created secret key to configure your source!
 
 ## IP allow list

--- a/docs/integrations/sources/google-tasks.md
+++ b/docs/integrations/sources/google-tasks.md
@@ -13,7 +13,7 @@ Currently Code granted OAuth 2.0 is not directly supported by airbyte, thus you 
 Steps:
 - Visit google cloud `https://console.cloud.google.com/apis/api/tasks.googleapis.com/metrics` and enable the tasks api service
 - Go to the consent screen `https://console.cloud.google.com/apis/credentials/consent` and add your email for enabling postman testing access
-- Visit `https://console.cloud.google.com/apis/credentials` and create new credentails for OAuth 2.0 and copy client id and client secret 
+- Visit `https://console.cloud.google.com/apis/credentials` and create new credentials for OAuth 2.0 and copy client id and client secret 
 - Add callback url `https://oauth.pstmn.io/v1/callback` while credential creation
 - Goto postman client and select new tab for setting authorization to OAuth 2.0
   - Set scope as `https://www.googleapis.com/auth/tasks https://www.googleapis.com/auth/tasks.readonly`

--- a/docs/integrations/sources/hubplanner.md
+++ b/docs/integrations/sources/hubplanner.md
@@ -12,7 +12,7 @@ Hubplanner is a tool to plan, schedule, report and manage your entire team.
 
 ## Airbyte Cloud
 
-- Comming Soon.
+- Coming Soon.
 
 ## Setup guide
 

--- a/docs/integrations/sources/linkedin-pages.md
+++ b/docs/integrations/sources/linkedin-pages.md
@@ -103,7 +103,7 @@ The source LinkedIn Pages can use either the `client_id`, `client_secret` and `r
      * `rw_organization_admin`
    * Click **Request access token** and once generated, **save your Refresh token**
 
-6. **Use the `client_id`, `client_secret` and `refresh_token`** from Steps 2 and 5 to autorize the LinkedIn Pages connector within the Airbyte UI.
+6. **Use the `client_id`, `client_secret` and `refresh_token`** from Steps 2 and 5 to authorize the LinkedIn Pages connector within the Airbyte UI.
    - As mentioned earlier, you can also simply use the Access token auth method for 60-day access.
 
 ## IP allow list

--- a/docs/integrations/sources/looker-migrations.md
+++ b/docs/integrations/sources/looker-migrations.md
@@ -8,7 +8,7 @@ Version 1.0.0 introduces changes to the connection configuration which has been 
 2. spaces and space_ancestors streams have been removed in favour of folders and folder_ancestors streams
 3. lookml_dashboards stream has been removed in favour of dashboards stream
 
-In addtion to affected streams, the schemas of the streams are expected to change.
+In addition to affected streams, the schemas of the streams are expected to change.
 
 For details about the API migration, check out [here](https://cloud.google.com/looker/docs/api-3x-deprecation)
 

--- a/docs/integrations/sources/microsoft-entra-id.md
+++ b/docs/integrations/sources/microsoft-entra-id.md
@@ -4,7 +4,7 @@ The Microsoft Entra ID Connector for Airbyte allows seamless integration with Mi
 
 ## Authentication
 
-First of all you need to register an application in the Microsoft Entra Admin Center. Please folow [these](https://learn.microsoft.com/en-us/graph/auth-register-app-v2) steps to do so. After that you need to follow [these](https://learn.microsoft.com/en-us/graph/auth-v2-service?context=graph%2Fapi%2F1.0&view=graph-rest-1.0&tabs=http) steps to configure the api with right permissions and get the access token.
+First of all you need to register an application in the Microsoft Entra Admin Center. Please follow [these](https://learn.microsoft.com/en-us/graph/auth-register-app-v2) steps to do so. After that you need to follow [these](https://learn.microsoft.com/en-us/graph/auth-v2-service?context=graph%2Fapi%2F1.0&view=graph-rest-1.0&tabs=http) steps to configure the api with right permissions and get the access token.
 
 ## Configuration
 

--- a/docs/integrations/sources/netsuite.md
+++ b/docs/integrations/sources/netsuite.md
@@ -41,7 +41,7 @@ This connector implements the [SuiteTalk REST Web Services](https://docs.oracle.
 5. Scroll down to **Manage Authentication** section
 6. Enable checkbox `TOKEN-BASED AUTHENTICATION`
 7. Scroll down to **SuiteTalk (Web Services)**
-8. Enable checkbox `REST WEB SERVISES`
+8. Enable checkbox `REST WEB SERVICES`
 9. Save the changes
 
 #### Step 2.3: Create Integration (obtain Consumer Key and Consumer Secret)

--- a/docs/integrations/sources/openfda.md
+++ b/docs/integrations/sources/openfda.md
@@ -1,6 +1,6 @@
 # OpenFDA
 OpenFDA provides access to a number of high-value, high priority and scalable structured datasets, including adverse events, drug product labeling, and recall enforcement reports.
-With this conenctor we can fetch data from the streams like Drugs , Animal and Veterinary Adverse Events and Food Adverse Events etc.
+With this connector we can fetch data from the streams like Drugs , Animal and Veterinary Adverse Events and Food Adverse Events etc.
 Docs:https://open.fda.gov/apis/
 
 ## Configuration

--- a/docs/integrations/sources/opsgenie.md
+++ b/docs/integrations/sources/opsgenie.md
@@ -35,7 +35,7 @@ Opsgenie has [rate limits](https://docs.opsgenie.com/docs/api-rate-limiting), bu
 ### Requirements
 
 - Opsgenie Account
-- Opsgenie API Key wih the necessary permissions \(described below\)
+- Opsgenie API Key with the necessary permissions \(described below\)
 
 ### Setup Guide
 

--- a/docs/integrations/sources/orb.md
+++ b/docs/integrations/sources/orb.md
@@ -17,7 +17,7 @@ This Source is capable of syncing the following core resources, each of which ha
 
 As a caveat, the Credits Ledger Entries must read all Customers for an incremental sync, but will only incrementally return new ledger entries for each customers.
 
-Similarily, the Subscription Usage stream must read all Subscriptions for an incremental sync (and all Plans if using the optional `subscription_usage_grouping_key`), but will only incrementally return new usage entries for each subscription.
+Similarly, the Subscription Usage stream must read all Subscriptions for an incremental sync (and all Plans if using the optional `subscription_usage_grouping_key`), but will only incrementally return new usage entries for each subscription.
 
 ### Note on Incremental Syncs
 

--- a/docs/integrations/sources/outreach-migrations.md
+++ b/docs/integrations/sources/outreach-migrations.md
@@ -1,7 +1,7 @@
 # Outreach Migration Guide
 
 ## Upgrading to 1.0.0
-The verison migrates the Outreach connector to the low-code framework for greater maintainability. 
+The version migrates the Outreach connector to the low-code framework for greater maintainability. 
 Important update: The sequence_steps stream schema from API has a breaking change to the creator field to an array containing integers instead of strings.
 Destination should adapt to this change if needed.
 You may need to refresh the connection schema (with the reset), and run a sync.

--- a/docs/integrations/sources/paypal-transaction.md
+++ b/docs/integrations/sources/paypal-transaction.md
@@ -32,7 +32,7 @@ After creating your account you will be able to get your `Client ID` and `Secret
 4. Enter your `Client ID`
 5. Enter your `Client secret`
 6. `Start Date`: Use the provided datepicker or enter manually a UTC date and time in the format `YYYY-MM-DDTHH:MM:SSZ`.
-7. Switch ON/Off the Sandbox toggle. By default the toggle is OFF, meaning it work only in a production environment.
+7. Switch ON/Off the Sandbox toggle. By default the toggle is OFF, meaning it works only in a production environment.
 8. \_(Optional) `Dispute Start Date Range`: Use the provided datepicker or enter manually a UTC date and time in the format `YYYY-MM-DDTHH:MM:SS.sssZ`. - If you don't add a date and you sync the `lists_disputes stream`, it will use the default value of 180 days in the past to retrieve data - It is mandatory to add the milliseconds is you enter a datetime. - This option only works for `lists_disputes stream`
 
 9. _(Optional)`Refresh Token`:_ You can enter manually a refresh token. Right now the stream does this automatically.

--- a/docs/integrations/sources/paypal-transaction.md
+++ b/docs/integrations/sources/paypal-transaction.md
@@ -32,7 +32,7 @@ After creating your account you will be able to get your `Client ID` and `Secret
 4. Enter your `Client ID`
 5. Enter your `Client secret`
 6. `Start Date`: Use the provided datepicker or enter manually a UTC date and time in the format `YYYY-MM-DDTHH:MM:SSZ`.
-7. Switch ON/Off the Sandbox toggle. By defaukt the toggle is OFF, meaning it work only in a produciton environment.
+7. Switch ON/Off the Sandbox toggle. By default the toggle is OFF, meaning it work only in a production environment.
 8. \_(Optional) `Dispute Start Date Range`: Use the provided datepicker or enter manually a UTC date and time in the format `YYYY-MM-DDTHH:MM:SS.sssZ`. - If you don't add a date and you sync the `lists_disputes stream`, it will use the default value of 180 days in the past to retrieve data - It is mandatory to add the milliseconds is you enter a datetime. - This option only works for `lists_disputes stream`
 
 9. _(Optional)`Refresh Token`:_ You can enter manually a refresh token. Right now the stream does this automatically.
@@ -72,7 +72,7 @@ This Source is capable of syncing the following core Streams:
 
 ### Transactions Stream
 
-The below table contains the configuraiton parameters available for this connector and the default values and available features
+The below table contains the configuration parameters available for this connector and the default values and available features
 
 | **Param/Feature**            | `Transactions`            |
 | :--------------------------- | :------------------------ |
@@ -93,7 +93,7 @@ The below table contains the configuraiton parameters available for this connect
 
 ### Balances Stream
 
-The below table contains the configuraiton parameters available for this connector and the default values and available features
+The below table contains the configuration parameters available for this connector and the default values and available features
 
 | **Param/Feature**            | `Balances`                |
 | :--------------------------- | :------------------------ |
@@ -114,7 +114,7 @@ The below table contains the configuraiton parameters available for this connect
 
 ### List Products Stream
 
-The below table contains the configuraiton parameters available for this connector and the default values and available features
+The below table contains the configuration parameters available for this connector and the default values and available features
 
 | **Param/Feature**            | `List Products`        |
 | :--------------------------- | :--------------------- |
@@ -133,7 +133,7 @@ The below table contains the configuraiton parameters available for this connect
 
 :::caution
 
-When configuring your stream take in consideration that the way the API works limits the speed on retreiving data. In some cases a +30K catalog retrieval could take between 10-15 minutes.
+When configuring your stream take in consideration that the way the API works limits the speed on retrieving data. In some cases a +30K catalog retrieval could take between 10-15 minutes.
 
 :::
 
@@ -141,7 +141,7 @@ When configuring your stream take in consideration that the way the API works li
 
 ### Show Products Stream
 
-The below table contains the configuraiton parameters available for this connector and the default values and available features
+The below table contains the configuration parameters available for this connector and the default values and available features
 
 | **Param/Feature**            | `Show Prod. Details`   |
 | :--------------------------- | :--------------------- |
@@ -160,7 +160,7 @@ The below table contains the configuraiton parameters available for this connect
 
 :::caution
 
-When configuring this stream consider that the parent stream paginates with 20 number of items (Max alowed page size). The Paypal API calls are not concurrent, so the time it takes depends entirely on the server side.
+When configuring this stream consider that the parent stream paginates with 20 number of items (Max allowed page size). The Paypal API calls are not concurrent, so the time it takes depends entirely on the server side.
 This stream could take a considerable time syncing, so you should consider running the sync of this and the parent stream (`list_products`) at the end of the day.
 Depending on the size of the catalog it could take several hours to sync.
 
@@ -170,7 +170,7 @@ Depending on the size of the catalog it could take several hours to sync.
 
 ### List Disputes Stream
 
-The below table contains the configuraiton parameters available for this connector and the default values and available features
+The below table contains the configuration parameters available for this connector and the default values and available features
 
 | **Param/Feature**            | `List Disputes`          |
 | :--------------------------- | :----------------------- |
@@ -191,7 +191,7 @@ The below table contains the configuraiton parameters available for this connect
 
 ### Search Invoices Stream
 
-The below table contains the configuraiton parameters available for this connector and the default values and available features
+The below table contains the configuration parameters available for this connector and the default values and available features
 
 | **Param/Feature**            | `Search Invoices`         |
 | :--------------------------- | :------------------------ |
@@ -220,7 +220,7 @@ The `start_end` from the configuration, is passed to the body of the request and
 
 ### List Payments Stream
 
-The below table contains the configuraiton parameters available for this connector and the default values and available features.
+The below table contains the configuration parameters available for this connector and the default values and available features.
 
 | **Param/Feature**            | `List Payments`           |
 | :--------------------------- | :------------------------ |

--- a/docs/integrations/sources/pexels-api.md
+++ b/docs/integrations/sources/pexels-api.md
@@ -17,7 +17,7 @@ Just pass the generated API key and optional parameters for establishing the con
   - query: Ocean, Tigers, Pears, etc. Default is people
   - orientation: landscape, portrait or square. Default is landscape
   - size: large, medium, small. Default is large
-  - color: red, orange, yellow, green, turquoise, blue, violet, pink, brown, black, gray, white or any hexidecimal color code.
+  - color: red, orange, yellow, green, turquoise, blue, violet, pink, brown, black, gray, white or any hexadecimal color code.
   - locale: en-US, pt-BR, es-ES, ca-ES, de-DE, it-IT, fr-FR, sv-SE, id-ID, pl-PL, ja-JP, zh-TW, zh-CN, ko-KR, th-TH, nl-NL, hu-HU, vi-VN, cs-CZ, da-DK, fi-FI, uk-UA, el-GR, ro-RO, nb-NO, sk-SK, tr-TR, ru-RU. Default is en-US
 
 ## Step 2: Set up the Pexels-APIs connector in Airbyte

--- a/docs/integrations/sources/rd-station-marketing.md
+++ b/docs/integrations/sources/rd-station-marketing.md
@@ -38,7 +38,7 @@ The RD Station Marketing source connector supports the following [sync modes](ht
 
 ## Performance considerations
 
-Each endpoint has its own performance limitations, which also consider the account plan. For more informations, visit the page [API request limit](https://developers.rdstation.com/reference/limite-de-requisicoes-da-api?lng=en).
+Each endpoint has its own performance limitations, which also consider the account plan. For more information, visit the page [API request limit](https://developers.rdstation.com/reference/limite-de-requisicoes-da-api?lng=en).
 
 ## IP allow list
 

--- a/docs/integrations/sources/redshift.md
+++ b/docs/integrations/sources/redshift.md
@@ -46,7 +46,7 @@ This is dependent on your networking setup. The easiest way to verify if Airbyte
 
 #### 2. Fill up connection info
 
-Next is to provide the necessary information on how to connect to your cluster such as the `host` whcih is part of the connection string or Endpoint accessible [here](https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-connect-to-cluster.html#rs-gsg-how-to-get-connection-string) without the `port` and `database` name \(it typically includes the cluster-id, region and end with `.redshift.amazonaws.com`\).
+Next is to provide the necessary information on how to connect to your cluster such as the `host` which is part of the connection string or Endpoint accessible [here](https://docs.aws.amazon.com/redshift/latest/gsg/rs-gsg-connect-to-cluster.html#rs-gsg-how-to-get-connection-string) without the `port` and `database` name \(it typically includes the cluster-id, region and end with `.redshift.amazonaws.com`\).
 
 ## Encryption
 

--- a/docs/integrations/sources/ringcentral.md
+++ b/docs/integrations/sources/ringcentral.md
@@ -13,7 +13,7 @@ Auth Token (which acts as bearer token), account id and extension id are mandate
 - Get your bearer token by following auth section (ref - https://developers.ringcentral.com/api-reference/authentication)
 - Setup params (All params are required)
 - Available params
-  - auth_token: Recieved by following https://developers.ringcentral.com/api-reference/authentication
+  - auth_token: Received by following https://developers.ringcentral.com/api-reference/authentication
   - account_id: Could be seen at response to basic api call to an endpoint with ~ operator. \
      \ Example- (https://platform.devtest.ringcentral.com/restapi/v1.0/account/~/extension/~/business-hours)
   - extension_id: Could be seen at response to basic api call to an endpoint with ~ operator. \

--- a/docs/integrations/sources/safetyculture.md
+++ b/docs/integrations/sources/safetyculture.md
@@ -5,7 +5,7 @@ This is the guide for the Safetyculture source connector which ingests data from
 ## Prerequisites
 
 This source uses the Authorization Bearer Token for handling requests. In order to obtain the credientials, you must first create a Safetyculture account.
-The API usage is only availabe for paid plans https://www.safetyculture.com/
+The API usage is only available for paid plans https://www.safetyculture.com/
 
 Once you have created your account, you can log in to your account.
 You can create an API token under Account Settings -> Integrations -> Manage MY API Tokens

--- a/docs/integrations/sources/salesloft.md
+++ b/docs/integrations/sources/salesloft.md
@@ -76,14 +76,14 @@ This connector outputs the following streams:
 - [Actions](https://developers.salesloft.com/api.html#!/Actions/get_v2_actions_json)
 - [Calls](https://developers.salesloft.com/api.html#!/Calls/get_v2_activities_calls_json)
 - [Emails Templates](https://developers.salesloft.com/api.html#!/Email_Templates/get_v2_email_templates_json)
-- [Emails Template Attachements](https://developers.salesloft.com/api.html#!/Email_Template_Attachments/get_v2_email_template_attachments_json)
+- [Emails Template Attachments](https://developers.salesloft.com/api.html#!/Email_Template_Attachments/get_v2_email_template_attachments_json)
 - [Imports](https://developers.salesloft.com/api.html#!/Imports/get_v2_imports_json)
 - [Notes](https://developers.salesloft.com/api.html#!/Notes/get_v2_notes_json)
 - [Person Stages](https://developers.salesloft.com/api.html#!/Person_Stages/get_v2_person_stages_json)
 - [Phone Number Assignments](https://developers.salesloft.com/api.html#!/Phone_Number_Assignments/get_v2_phone_number_assignments_json)
 - [Steps](https://developers.salesloft.com/api.html#!/Steps/get_v2_steps_json)
 - [Team Templates](https://developers.salesloft.com/api.html#!/Team_Templates/get_v2_team_templates_json)
-- [Team Template Attachements](https://developers.salesloft.com/api.html#!/Team_Template_Attachments/get_v2_team_template_attachments_json)
+- [Team Template Attachments](https://developers.salesloft.com/api.html#!/Team_Template_Attachments/get_v2_team_template_attachments_json)
 - [CRM Activities](https://developers.salesloft.com/api.html#!/CRM_Activities/get_v2_crm_activities_json)
 - [CRM Users](https://developers.salesloft.com/api.html#!/Crm_Users/get_v2_crm_users_json)
 - [Groups](https://developers.salesloft.com/api.html#!/Groups/get_v2_groups_json)
@@ -97,7 +97,7 @@ This connector outputs the following streams:
 
 ## Performance considerations
 
-Salesloft has the [rate limits](hhttps://developers.salesloft.com/api.html#!/Topic/RateLimiting), but the Salesloft connector should not run into Salesloft API limitations under normal usage. Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
+Salesloft has the [rate limits](https://developers.salesloft.com/api.html#!/Topic/RateLimiting), but the Salesloft connector should not run into Salesloft API limitations under normal usage. Please [create an issue](https://github.com/airbytehq/airbyte/issues) if you see any rate limit issues that are not automatically retried successfully.
 
 ## IP allow list
 

--- a/docs/integrations/sources/smartsheets.md
+++ b/docs/integrations/sources/smartsheets.md
@@ -67,7 +67,7 @@ At the time of writing, the [Smartsheets API rate limit](https://developers.smar
 This source provides a single stream per spreadsheet with a dynamic schema, depending on your spreadsheet structure.
 For example, having a spreadsheet `Customers`, the connector would introduce a stream with the same name and properties typed according to Data type map (see [below](https://docs.airbyte.com/integrations/sources/smartsheets/#data-type-map)).
 
-Additionallly specific metadata fields related to the sheet or row can be include in the stream, these must be specified in the configuration in order to be included in the data stream
+Additionally specific metadata fields related to the sheet or row can be include in the stream, these must be specified in the configuration in order to be included in the data stream
 
 | Supported Metadata Fields |
 | ------------------------- |

--- a/docs/integrations/sources/smartsheets.md
+++ b/docs/integrations/sources/smartsheets.md
@@ -67,7 +67,7 @@ At the time of writing, the [Smartsheets API rate limit](https://developers.smar
 This source provides a single stream per spreadsheet with a dynamic schema, depending on your spreadsheet structure.
 For example, having a spreadsheet `Customers`, the connector would introduce a stream with the same name and properties typed according to Data type map (see [below](https://docs.airbyte.com/integrations/sources/smartsheets/#data-type-map)).
 
-Additionally specific metadata fields related to the sheet or row can be include in the stream, these must be specified in the configuration in order to be included in the data stream
+Additionally specific metadata fields related to the sheet or row can be included in the stream, these must be specified in the configuration in order to be included in the data stream
 
 | Supported Metadata Fields |
 | ------------------------- |

--- a/docs/integrations/sources/teamtailor.md
+++ b/docs/integrations/sources/teamtailor.md
@@ -1,7 +1,7 @@
 # Teamtailor
 This is the setup for the Teamtailor source that ingests data from the teamtailor API.
 
-Teamtailor is a recruitment software, provding a new way to attract and hire top talent https://www.teamtailor.com/
+Teamtailor is a recruitment software, providing a new way to attract and hire top talent https://www.teamtailor.com/
 
 In order to use this source, you must first create an account on teamtailor.
 

--- a/docs/integrations/sources/thinkific-courses.md
+++ b/docs/integrations/sources/thinkific-courses.md
@@ -1,7 +1,7 @@
 # Thinkific Courses
 
 Thinkific is a leading platform for creating, marketing, and selling courses, digital products, communities and learning experiences.
-This connector retrives basic data information from courses.
+This connector retrieves basic data information from courses.
 
 ## Configuration
 

--- a/docs/integrations/sources/track-pms-migrations.md
+++ b/docs/integrations/sources/track-pms-migrations.md
@@ -5,12 +5,12 @@ Updates the units schema and removes `units.isOccupied` and `units.cleanStatusTy
 
 Please account for any downstream changes to `units` (e.g. remove database columns).
 
-Readded `reservations.guestBreakdown` to make the reservation rates available; however this doesn't typically return results so no declared schema has been alotted for it.
+Readded `reservations.guestBreakdown` to make the reservation rates available; however this doesn't typically return results so no declared schema has been allotted for it.
 Reservation rates  are also present in `reservations.quoteBreakdown` if `guestBreakdown` doesn't have any values.
 
-Other updates include fixes to the stream API links in the connector docs and updating error filter criteria - reducing 429 error retries from 10 to 3, and specifing a 409 error method.
+Other updates include fixes to the stream API links in the connector docs and updating error filter criteria - reducing 429 error retries from 10 to 3, and specifying a 409 error method.
 * The constant backoff strategy appears to be working (these seemed to be exponential in Airbyte versions < v1.5.1).
-* The Track API errouneous 409 error is set to one retry, though 0 would be preferred (the Airbyte UI, as of v1.5.1, automatically removes the number of retries alltogether if 0). Might have to circle back on this one.
+* The Track API erroneous 409 error is set to one retry, though 0 would be preferred (the Airbyte UI, as of v1.5.1, automatically removes the number of retries altogether if 0). Might have to circle back on this one.
 
 ## Upgrading to 3.0.0
 

--- a/docs/integrations/sources/trustpilot.md
+++ b/docs/integrations/sources/trustpilot.md
@@ -29,7 +29,7 @@ Content-Type: application/x-www-form-urlencoded
 grant_type=password&username=YOUR_TRUSTPILOT_USERNAME_OR_LOGIN_EMAIL_HERE&password=YOUR_TRUSTPILOT_PASSWORD_HERE
 ```
 
-When succeeded, it will return a json object. Extrat the properties `access_token`, `refresh_token`.
+When succeeded, it will return a json object. Extract the properties `access_token`, `refresh_token`.
 
 Fill now the missing configuration fields in the Airbyte source configuration. As token expiry date, use the current time + 4 days (or calculate it yourself by calculating the date time of request add the seconds given in property `expires_in`).
 

--- a/docs/integrations/sources/twelve-data.md
+++ b/docs/integrations/sources/twelve-data.md
@@ -1,6 +1,6 @@
 # Twelve Data
 Twelve data can be used to access the data of world financial markets including stocks, forex, ETFs, indices, and cryptocurrencies.
-This connector has various streams including but not limited to Stocks , Forex Pairs , Crypto Currencies , Time Series and Techical Indicators
+This connector has various streams including but not limited to Stocks , Forex Pairs , Crypto Currencies , Time Series and Technical Indicators
 
 Docs : https://twelvedata.com/docs
 

--- a/docs/integrations/sources/zuora.md
+++ b/docs/integrations/sources/zuora.md
@@ -79,15 +79,15 @@ Any other data type not listed in the table above will be treated as `string`.
 
 | Environment | Supported?\(Yes/No\) | Notes                                   |
 | :---------- | :------------------- | :-------------------------------------- |
-| Production  | Yes                  | Select from exising options while setup |
-| Sandbox     | Yes                  | Select from exising options while setup |
+| Production  | Yes                  | Select from existing options while setup |
+| Sandbox     | Yes                  | Select from existing options while setup |
 
 ## Supported Data Query options
 
 | Option    | Supported?\(Yes/No\) | Notes                                                                                                                                                                                                                                                                                                 |
 | :-------- | :------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | LIVE      | Yes                  | Run data queries against Zuora live transactional databases                                                                                                                                                                                                                                           |
-| UNLIMITED | Yes                  | Run data queries against an optimized, replicated database at 12 hours freshness for high volume extraction use cases (Early Adoption, additionall access required, contact [Zuora Support](http://support.zuora.com/hc/en-us) in order to request this feature enabled for your account beforehand.) |
+| UNLIMITED | Yes                  | Run data queries against an optimized, replicated database at 12 hours freshness for high volume extraction use cases (Early Adoption, additional access required, contact [Zuora Support](http://support.zuora.com/hc/en-us) in order to request this feature enabled for your account beforehand.) |
 
 ## List of Supported Environments for Zuora
 
@@ -132,10 +132,10 @@ Usually, the very first sync operation for all of the objects inside Zuora accou
 
 ### Create an API user role
 
-1. Log in to your `Zuora acccount`.
+1. Log in to your `Zuora account`.
 2. In the top right corner of the Zuora dashboard, select `Settings` &gt; `Administration Settings`.
 3. Select `Manage User Roles`.
-4. Select `Add new role` to create a new role, and fill in neccessary information up to the form.
+4. Select `Add new role` to create a new role, and fill in necessary information up to the form.
 
 ### Assign the role to a user
 

--- a/docs/platform/connector-development/cdk-python/schemas.md
+++ b/docs/platform/connector-development/cdk-python/schemas.md
@@ -65,7 +65,7 @@ In this case default transformation will be applied. For example if you have sch
 {"type": "object", "properties": {"value": {"type": "string"}}}
 ```
 
-and source API returned object with non-string type, it would be casted to string automaticaly:
+and source API returned object with non-string type, it would be casted to string automatically:
 
 ```javascript
 {"value": 12} -> {"value": "12"}
@@ -79,9 +79,9 @@ Also it works on complex types:
 
 And objects inside array of referenced by $ref attribute.
 
-If the value cannot be cast \(e.g. string "asdf" cannot be casted to integer\), the field would retain its original value. Schema type transformation support any jsonschema types, nested objects/arrays and reference types. Types described as array of more than one type \(except "null"\), types under oneOf/anyOf keyword wont be transformed.
+If the value cannot be cast \(e.g. string "asdf" cannot be casted to integer\), the field would retain its original value. Schema type transformation support any jsonschema types, nested objects/arrays and reference types. Types described as array of more than one type \(except "null"\), types under oneOf/anyOf keyword won't be transformed.
 
-_Note:_ This transformation is done by the source, not the stream itself. I.e. if you have overriden "read_records" method in your stream it wont affect object transformation. All transformation are done in-place by modifing output object before passing it to "get_updated_state" method, so "get_updated_state" would receive the transformed object.
+_Note:_ This transformation is done by the source, not the stream itself. I.e. if you have overridden "read_records" method in your stream it won't affect object transformation. All transformation are done in-place by modifying output object before passing it to "get_updated_state" method, so "get_updated_state" would receive the transformed object.
 
 ### Custom schema type transformation
 

--- a/docs/platform/connector-development/cdk-python/schemas.md
+++ b/docs/platform/connector-development/cdk-python/schemas.md
@@ -81,7 +81,7 @@ And objects inside array of referenced by $ref attribute.
 
 If the value cannot be cast \(e.g. string "asdf" cannot be casted to integer\), the field would retain its original value. Schema type transformation support any jsonschema types, nested objects/arrays and reference types. Types described as array of more than one type \(except "null"\), types under oneOf/anyOf keyword won't be transformed.
 
-_Note:_ This transformation is done by the source, not the stream itself. I.e. if you have overridden "read_records" method in your stream it won't affect object transformation. All transformation are done in-place by modifying output object before passing it to "get_updated_state" method, so "get_updated_state" would receive the transformed object.
+_Note:_ This transformation is done by the source, not the stream itself. I.e. if you have overridden "read_records" method in your stream it won't affect object transformation. All transformations are done in-place by modifying output object before passing it to "get_updated_state" method, so "get_updated_state" would receive the transformed object.
 
 ### Custom schema type transformation
 

--- a/docs/platform/connector-development/config-based/advanced-topics/oauth.md
+++ b/docs/platform/connector-development/config-based/advanced-topics/oauth.md
@@ -486,7 +486,7 @@ and the response of `/oauth/token` now includes a refresh token field.
   </details>
 
 #### Advanced Case: scopes should be provided as a query parameter
-Imagine that the OAuth flow is updated so that you need to mention the `scope` query parameter to get to the `consent screen` and verify / grant the access to the neccessary onces, before moving forward.
+Imagine that the OAuth flow is updated so that you need to mention the `scope` query parameter to get to the `consent screen` and verify / grant the access to the necessary ones, before moving forward.
 
   <details>
       <summary>Example Declarative OAuth Change</summary>
@@ -546,7 +546,7 @@ Imagine that the OAuth flow is updated so that you need to mention the `state` q
 
 
 ##### Example using an url-encoded / url-decoded `scope` parameter
-You can make the `scope` paramter `url-encoded` by specifying the `pipe` ( | ) + `urlencode` or `urldecode` in the target url.
+You can make the `scope` parameter `url-encoded` by specifying the `pipe` ( | ) + `urlencode` or `urldecode` in the target url.
 It would be pre-formatted and resolved into the `url-encoded` string before being replaced for the final resolved URL.
 
   <details>
@@ -795,7 +795,7 @@ code_value}}
 
 ### Available Template Variables PIPE methods
 
-You can apply the `in-variable` tranformations based on your use-case and use the following interpolation methods available:
+You can apply the `in-variable` transformations based on your use-case and use the following interpolation methods available:
 
 #### Most useful interpolation methods used for OAuth
 
@@ -860,7 +860,7 @@ You can apply the `in-variable` tranformations based on your use-case and use th
 | timeuntil       | Returns the time until a date.                 | `{{ date\|timeuntil }}`                            | `'in 2 days'`                                                                  |
 
 ### Common Use-Cases and Examples:
-The following section stands to describe common use-cases. Assuming that there are no overides provided over the `default` keys, the common specification parts (properties) like: `complete_oauth_server_input_specification` and `complete_oauth_server_output_specification` remain unchanged
+The following section stands to describe common use-cases. Assuming that there are no overrides provided over the `default` keys, the common specification parts (properties) like: `complete_oauth_server_input_specification` and `complete_oauth_server_output_specification` remain unchanged
 
   <details>
       <summary>Example Common Advanced Auth parts</summary>
@@ -1120,7 +1120,7 @@ oauth_config_specification:
   </details>
 
 #### Case D: OAuth Flow returns the `access_token` and the `refresh_token` is a `one-time-usage` key
-In this example we expect the `refresh_token` key expires alongside with the `access_token` and should be exhanged altogether, having the new pair of keys in response. The `token_expiry_date` is the property that holds the `date-time` value of when the `access_token` should be expired
+In this example we expect the `refresh_token` key expires alongside with the `access_token` and should be exchanged altogether, having the new pair of keys in response. The `token_expiry_date` is the property that holds the `date-time` value of when the `access_token` should be expired
 
   <details>
       <summary>Example Declarative OAuth Specification</summary>

--- a/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
+++ b/docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md
@@ -139,10 +139,10 @@ retriever:
   <...>
   requester:
     <...>
-    path: "/respositories/{{ stream_slice.repository }}/commits"
+    path: "/repositories/{{ stream_slice.repository }}/commits"
   partition_router:
     type: SubstreamPartitionRouter
-    parent_streams_configs:
+    parent_stream_configs:
       - stream: "#/repositories_stream"
         parent_key: "id"
         partition_field: "repository"

--- a/docs/platform/connector-development/connector-breaking-changes.md
+++ b/docs/platform/connector-development/connector-breaking-changes.md
@@ -161,7 +161,7 @@ The `upgradeDeadline` field specifies the date by which users should upgrade (fo
 
 - **Rationale:** The deadline should provide enough time for users to review the migration guide, test in staging environments, and execute the migration steps.
 
-- **Exception: Immediate upstream breakage:** In the case of immediate upstream breaking changes, such as an already-removed upstream API endpoint, the deadline can be present-day or even in the past - with the rationale that users' connections are _already_ broken without the fix and therefor need the upgrade applied immediately.
+- **Exception: Immediate upstream breakage:** In the case of immediate upstream breaking changes, such as an already-removed upstream API endpoint, the deadline can be present-day or even in the past - with the rationale that users' connections are _already_ broken without the fix and therefore need the upgrade applied immediately.
 
 - **Automated notifications:** The platform automatically emails users when a breaking change is released and sends reminders as the deadline approaches.
 

--- a/docs/platform/connector-development/connector-builder-ui/incremental-sync.md
+++ b/docs/platform/connector-development/connector-builder-ui/incremental-sync.md
@@ -76,7 +76,7 @@ Setting the start date in the "Testing values" to a date in the past like **2023
 curl 'https://content.guardianapis.com/search?from-date=<b>2023-04-09T00:00:00Z</b>&to-date={`now`}'
 ```
 
-The most recent encountered date will be saved as the [*state*](../../understanding-airbyte/airbyte-protocol.md#state--checkpointing) of the connection - when the next sync is running, it picks up from that cutoff date as the new start date. Let's assume the last ecountered article looked like this:
+The most recent encountered date will be saved as the [*state*](../../understanding-airbyte/airbyte-protocol.md#state--checkpointing) of the connection - when the next sync is running, it picks up from that cutoff date as the new start date. Let's assume the last encountered article looked like this:
 
 ```json
 {`{

--- a/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
+++ b/docs/platform/connector-development/connector-builder-ui/record-processing.mdx
@@ -315,7 +315,7 @@ The Field Path feature lets you define a path into the fields of the response to
 Below are a few different examples of what this can look like depending on the API.
 
 #### Top-level key pointing to array
-Very often, the response body contains an array of records along with some suplementary information (for example meta data for pagination).
+Very often, the response body contains an array of records along with some supplementary information (for example meta data for pagination).
 
 For example the ["Most popular" NY Times API](https://developer.nytimes.com/docs/most-popular-product/1/overview) returns the following response body:
 

--- a/docs/platform/connector-development/connector-metadata-file.md
+++ b/docs/platform/connector-development/connector-metadata-file.md
@@ -112,7 +112,7 @@ their associated breaking changes. Each entry must contain the following paramet
 - `message`: A description of the breaking change, written in a user-friendly format. This message should briefly describe
   - What the breaking change is, and which users it effects (e.g. all users of the source, or only those using a certain stream)
   - Why the change is better for the user (fixed a bug, something got faster, etc)
-  - What the user should do to fix the issue (e.g. a full reset, run a SQL query in the destinaton, etc)
+  - What the user should do to fix the issue (e.g. a full reset, run a SQL query in the destination, etc)
 - `upgradeDeadline`: (`YYYY-MM-DD`) The date by which the user should upgrade to the new version.
 
 When considering what the `upgradeDeadline` should be, target the amount of time which would be reasonable for the user to make the required changes described in the `message` and upgrade giude. If the required changes are _simple_ (e.g. "do a full reset"), 2 weeks is recommended. Note that you do _not_ want to link the duration of `upgradeDeadline` to an upstream API's deprecation date. While it is true that the older version of a connector will continue to work for that period of time, it means that users who are pinned to the older version of the connector will not benefit from future updates and fixes.

--- a/docs/platform/connector-development/connector-specification-reference.md
+++ b/docs/platform/connector-development/connector-specification-reference.md
@@ -64,7 +64,7 @@ By default, all optional fields will be collapsed into an `Optional fields` sect
 
 These `Optional fields` sections are placed at the bottom of a field group, meaning that all required fields in the same group will be placed above it. To interleave optional fields with required fields, set `always_show: true` on the optional field along with an `order`, which will cause the field to no longer be collapsed in an `Optional fields` section and be ordered as normal.
 
-**Note:** `always_show` also causes fields that are normally hidden by an OAuth button to still be shwon.
+**Note:** `always_show` also causes fields that are normally hidden by an OAuth button to still be shown.
 
 Within a collapsed `Optional fields` section, the optional fields' `order` defines their position in the section; those without an `order` will be placed after fields with an `order`, and will themselves be ordered alphabetically by field name.
 

--- a/docs/platform/connector-development/debugging-docker.md
+++ b/docs/platform/connector-development/debugging-docker.md
@@ -110,7 +110,7 @@ If you ran through the [Postgres to Postgres replication tutorial](https://airby
 
 On the connection page, trigger a manual sync with the "Sync now" button. Because we set the `suspend` option to `y` in our `JAVA_TOOL_OPTIONS` the
 container will pause all execution until the debugger is connected. This can be very useful for methods which run very quickly, such as the Check method.
-However, this could be very detrimental if it were pushed into a production environment. For now, it gives us time to set a new Remote JVM Debug Configuraiton.
+However, this could be very detrimental if it were pushed into a production environment. For now, it gives us time to set a new Remote JVM Debug Configuration.
 
 This container will have a different IP than the `server` Remote JVM Debug Run configuration we set up earlier. So lets set up a new one with the IP of
 the `destination-postgres` container:

--- a/docs/platform/connector-development/testing-connectors/connector-acceptance-tests-reference.md
+++ b/docs/platform/connector-development/testing-connectors/connector-acceptance-tests-reference.md
@@ -477,7 +477,7 @@ data:
       - "*.hubspot.com"
 ```
 
-A list of dynamic hostnames or IP addresses which reference values from the connector's configuration. The variable names need to match the connector's config exactly. In this example, `subdomain` is a required option defined by the connector's SPEC response. It is also possible to refrence sub-fields with dot-notation, e.g. `networking_options.tunnel_host`.
+A list of dynamic hostnames or IP addresses which reference values from the connector's configuration. The variable names need to match the connector's config exactly. In this example, `subdomain` is a required option defined by the connector's SPEC response. It is also possible to reference sub-fields with dot-notation, e.g. `networking_options.tunnel_host`.
 
 ```yaml
 data:

--- a/docs/platform/connector-development/tutorials/building-a-java-destination.md
+++ b/docs/platform/connector-development/tutorials/building-a-java-destination.md
@@ -241,7 +241,7 @@ incoming data and how it should be written to the destination. Its "output" is t
 
 To implement the `write` Airbyte operation, implement the `getConsumer` method in your generated
 `<Name>Destination.java` file. Here are some example implementations from different destination
-conectors:
+connectors:
 
 - [BigQuery](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-bigquery/src/main/java/io/airbyte/integrations/destination/bigquery/BigQueryDestination.java#L188)
 - [Google Pubsub](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/destination-pubsub/src/main/java/io/airbyte/integrations/destination/pubsub/PubsubDestination.java#L98)

--- a/docs/platform/deploying-airbyte/chart-v2-community.mdx
+++ b/docs/platform/deploying-airbyte/chart-v2-community.mdx
@@ -278,7 +278,7 @@ global:
 
 <details>
 <summary>
-Update syntax for other customizatons
+Update syntax for other customizations
 </summary>
 
 If you have further customizations in your V1 values.yaml file, move those over to your new values.yaml file, and update key names where appropriate.

--- a/docs/platform/deploying-airbyte/integrations/secrets.md
+++ b/docs/platform/deploying-airbyte/integrations/secrets.md
@@ -78,7 +78,7 @@ stringData:
 
 ## Values
 
-Modifing the configuration of connector secret storage will cause all <i>existing</i> connectors to fail. You will need to recreate these connectors to ensure they are reading from the appropriate secret store.
+Modifying the configuration of connector secret storage will cause all <i>existing</i> connectors to fail. You will need to recreate these connectors to ensure they are reading from the appropriate secret store.
 
 <Tabs>
 <TabItem label="Amazon" value="Amazon" default>

--- a/docs/platform/deploying-airbyte/troubleshoot-deploy.md
+++ b/docs/platform/deploying-airbyte/troubleshoot-deploy.md
@@ -78,7 +78,7 @@ failed with error: exit status 125
 
 We recommend that you copy and run the `docker run` command manually.
 This may provide more meaningful error messages explaining why it is failing.
-Running manually the sucessful output says kubeadm was able to join worker nodes.
+Running manually the successful output says kubeadm was able to join worker nodes.
 Additionally, verify that you can run Docker containers in general by starting with `docker run hello-world`.
 
 ```shell

--- a/docs/platform/operator-guides/configuring-airbyte.md
+++ b/docs/platform/operator-guides/configuring-airbyte.md
@@ -23,7 +23,7 @@ Be careful using variables marked as `alpha`. They aren't meant for public consu
 4. `VAULT_ADDRESS` - Defines the vault address to read/write Airbyte Configuration to Hashicorp Vault. Alpha Support.
 5. `VAULT_PREFIX` - Defines the vault path prefix. Should follow the format `<engine>/<directory>/`, for example `kv/airbyte/` or `secret/airbyte/`. Empty by default. Alpha Support.
 6. `VAULT_AUTH_TOKEN` - The token used for vault authentication. Alpha Support.
-7. `VAULT_AUTH_METHOD` - How vault will preform authentication. Currently, only supports Token auth. Defaults to token. Alpha Support.
+7. `VAULT_AUTH_METHOD` - How vault will perform authentication. Currently, only supports Token auth. Defaults to token. Alpha Support.
 8. `AWS_ACCESS_KEY` - Defines the aws_access_key_id from the AWS credentials to use for AWS Secret Manager.
 9. `AWS_SECRET_ACCESS_KEY`- Defines aws_secret_access_key to use for the AWS Secret Manager.
 10. `AWS_KMS_KEY_ARN` - Optional param that defines the KMS Encryption key used for the AWS Secret Manager.

--- a/docs/platform/operator-guides/refreshes.md
+++ b/docs/platform/operator-guides/refreshes.md
@@ -99,13 +99,13 @@ Notice that user #2’s latest entry doesn’t belong to the current (e.g. `max(
 
 ### How is a Full Refresh sync that uses Append + Overwrite to write to the destination different from a refresh?
 
-They're completely identical! A Full Refresh | Append + Overwite sync is running a refresh on every sync and retaining all records. A Full Refresh | Overwrite sync is running a refresh on every sync and removing any reecords that no longer appear in the source. Notably, this means that `_airbyte_generation_id` will increment on every sync.
+They're completely identical! A Full Refresh | Append + Overwrite sync is running a refresh on every sync and retaining all records. A Full Refresh | Overwrite sync is running a refresh on every sync and removing any records that no longer appear in the source. Notably, this means that `_airbyte_generation_id` will increment on every sync.
 
 ### Does the generation ID reset to 0 after running a Clear and sync again? 
 
 The generation ID will be incremented whenever you run a clear or refresh. Airbyte will never decrease the generation ID.
 
-Iif you run a Refresh immediately after running a Clear (including syncing a full refresh stream normally, as noted in the above question, that will _also_ increment the generation ID. This means the generation ID will increment twice, even though one of those "generations" never emitted any records.
+If you run a Refresh immediately after running a Clear (including syncing a full refresh stream normally, as noted in the above question, that will _also_ increment the generation ID. This means the generation ID will increment twice, even though one of those "generations" never emitted any records.
 
 ### For DV2 destinations, how do clears or Refreshes that remove records interact with the raw and final tables?
 

--- a/docs/platform/understanding-airbyte/airbyte-protocol.md
+++ b/docs/platform/understanding-airbyte/airbyte-protocol.md
@@ -572,7 +572,7 @@ There are 3 types of state: Stream, Global, and Legacy.
 
 - **Stream** represents Sources where there is complete isolation between stream states. In these cases, the state for each stream will be emitted in its own state message. In other words, if there are 3 streams replicated during a sync, the Source would emit at least 3 state message (1 per stream). The state of the Source is the sum of all the stream states.
 - **Global** represents Sources where this shared state across streams. In these cases each state message contains the whole state for the connection. The `shared_state` field is where any information that is shared across streams must go. The `stream_states` field contains a list of objects that contain a Stream Descriptor and the state information for that stream that is stream-specific. There are drawbacks to this state type, so it should only be used in cases where a shared state between streams is unavoidable.
-- **Legacy** exists for backwards compatibility. In this state type, the state object is totally a black box. The only inference tha can be drawn from the state object is that if it is null, then there is no state for the entire Source. **All current legacy cases are being ported to stream or global. Once they are, it will be removed.**
+- **Legacy** exists for backwards compatibility. In this state type, the state object is totally a black box. The only inference that can be drawn from the state object is that if it is null, then there is no state for the entire Source. **All current legacy cases are being ported to stream or global. Once they are, it will be removed.**
 
 This table breaks down attributes of these state types.
 
@@ -879,7 +879,7 @@ AirbyteLogMessage:
 
 ### AirbyteTraceMessage
 
-The trace message allows an Actor to emit metadata about the runtime of the Actor, such as errors or estimates. This message is designed to grow to handle other use cases, including additonal performance metrics.
+The trace message allows an Actor to emit metadata about the runtime of the Actor, such as errors or estimates. This message is designed to grow to handle other use cases, including additional performance metrics.
 
 ```yaml
 AirbyteTraceMessage:

--- a/docs/platform/understanding-airbyte/jobs.md
+++ b/docs/platform/understanding-airbyte/jobs.md
@@ -133,7 +133,7 @@ Workloads is an Airbyte-internal job abstraction decoupling the number of runnin
 
 Dumb workers now communicate with the Workload API Server to create a Workload instead of directly starting jobs.
 
-The **Workload API Server** places the job in a queue. The **Launcher** picks up the job and launches the resources needed to run the job e.g. Kuberenetes pods. It throttles job creation based on available resources, minimising deadlock situations.
+The **Workload API Server** places the job in a queue. The **Launcher** picks up the job and launches the resources needed to run the job e.g. Kubernetes pods. It throttles job creation based on available resources, minimising deadlock situations.
 
 With this set up, Airbyte now supports:
 

--- a/docs/platform/understanding-airbyte/supported-data-types.md
+++ b/docs/platform/understanding-airbyte/supported-data-types.md
@@ -169,7 +169,7 @@ Airbyte does not currently support infinity/NaN values.
 
 Arrays contain 0 or more items, which must have a defined type. These types should also conform to the type system. Arrays may require that all of their elements be the same type (`"items": {whatever type...}`). They may instead require each element to conform to one of a list of types (`"items": [{first type...}, {second type...}, ... , {Nth type...}]`).
 
-Note that Airbyte's usage of the `items` field is slightly different than JSON schema's usage, in which an `"items": [...]` actually constrains the element correpsonding to the index of that item (AKA tuple-typing). This is becase destinations may have a difficult time supporting tuple-typed arrays without very specific handling, and as such are permitted to somewhat loosen their requirements.
+Note that Airbyte's usage of the `items` field is slightly different than JSON schema's usage, in which an `"items": [...]` actually constrains the element corresponding to the index of that item (AKA tuple-typing). This is because destinations may have a difficult time supporting tuple-typed arrays without very specific handling, and as such are permitted to somewhat loosen their requirements.
 
 #### Objects
 

--- a/docs/platform/using-airbyte/_configure_file_metadata.mdx
+++ b/docs/platform/using-airbyte/_configure_file_metadata.mdx
@@ -14,7 +14,7 @@ To change the format of the metadata, change the output format on the Destinatio
 
 3. Under **Output Format**, choose the file format you want. You can also choose whether you want to compress the file, or if you want to flatten it.
 
-    ![Choosing JSON Lines format as the Output Format on the Destinaton configuration for the S3 destination](images/output-format.png)
+    ![Choosing JSON Lines format as the Output Format on the Destination configuration for the S3 destination](images/output-format.png)
 
 4. Click **Test and save**. Next time you sync, your metadata has the chosen format.
 


### PR DESCRIPTION
## What
Documentation-only fixes.

The `SubstreamPartitionRouter` example in `docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md` has two copy-paste breakers in the same YAML block: it uses the key `parent_streams_configs` (the three other examples in the file, and the schema, use `parent_stream_configs`), and its requester path is `/respositories/...` while the prose two lines above says the URL is `/repositories/:id/commits`.

Also fixed:
- two links that began with `hhttps://` in `docs/integrations/sources/genesys.md` and `salesloft.md`
- a doubled "the" in `docs/community/contributing-to-airbyte/resources/pull-requests-handbook.md`
- spelling errors in prose across the platform, deployment, and connector docs (e.g. `Kuberenetes`, `neccessary`, `configuraiton`, `Iif`, `Overwite`)

## How
Word-boundary substitutions on the affected lines only. No code, changelog tables, versioned docs, generated references, product names, or code identifiers were touched.

## Review guide
1. `docs/platform/connector-development/config-based/understanding-the-yaml-file/partition-router.md`
2. `docs/integrations/sources/genesys.md`, `docs/integrations/sources/salesloft.md`
3. Everything else is one-word spelling changes; `git diff --word-diff` shows them compactly.

## User Impact
The partition router sample can now be copied without failing validation or 404ing. Otherwise none.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌