### PR TITLE
fix(destination-bigquery): retry transient errors on batched standard-insert uploads

### DIFF
--- a/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/destination-bigquery/metadata.yaml
@@ -6,7 +6,7 @@ data:
   connectorSubtype: database
   connectorType: destination
   definitionId: 22f6c74f-5699-40ff-833c-4a879ea40133
-  dockerImageTag: 3.1.1
+  dockerImageTag: 3.1.2
   dockerRepository: airbyte/destination-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/destinations/bigquery
   githubIssueLabel: destination-bigquery

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
@@ -117,8 +117,8 @@ class BigqueryBatchStandardInsertsLoader(
      * the resumable upload endpoint.
      *
      * Every attempt reuses the same [JobId]. BigQuery job IDs are unique per project, so if a
-     * previous attempt's upload actually completed (and the load job was created) we detect that via
-     * [BigQuery.getJob] and wait for that job instead of re-submitting the data, which avoids
+     * previous attempt's upload actually completed (and the load job was created) we detect that
+     * via [BigQuery.getJob] and wait for that job instead of re-submitting the data, which avoids
      * duplicate loads.
      */
     private suspend fun uploadWithRetries(): Job {

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
@@ -108,8 +108,11 @@ class BigqueryBatchStandardInsertsLoader(
     }
 
     override fun close() {
-        spillOutput.close()
-        Files.deleteIfExists(spillFile)
+        try {
+            spillOutput.close()
+        } finally {
+            Files.deleteIfExists(spillFile)
+        }
     }
 
     /**
@@ -125,16 +128,16 @@ class BigqueryBatchStandardInsertsLoader(
         var retryDelayMs = initialRetryDelayMs
         var lastException: BigQueryException? = null
         for (attempt in 1..maxUploadAttempts) {
-            if (attempt > 1) {
-                val existingJob = bigquery.getJob(job)
-                if (existingJob != null) {
-                    logger.info {
-                        "Load job ${job.job} already exists after a failed upload attempt; waiting for it instead of re-uploading."
-                    }
-                    return existingJob
-                }
-            }
             try {
+                if (attempt > 1) {
+                    val existingJob = bigquery.getJob(job)
+                    if (existingJob != null) {
+                        logger.info {
+                            "Load job ${job.job} already exists after a failed upload attempt; waiting for it instead of re-uploading."
+                        }
+                        return existingJob
+                    }
+                }
                 return uploadOnce()
             } catch (e: BigQueryException) {
                 if (!isRetryableUploadError(e)) {
@@ -168,13 +171,24 @@ class BigqueryBatchStandardInsertsLoader(
                     throw e
                 }
             }
-        Files.newInputStream(spillFile).use { input ->
-            val chunk = ByteArray(UPLOAD_CHUNK_SIZE_BYTES)
-            while (true) {
-                val read = input.read(chunk)
-                if (read < 0) break
-                writer.write(ByteBuffer.wrap(chunk, 0, read))
+        try {
+            Files.newInputStream(spillFile).use { input ->
+                val chunk = ByteArray(UPLOAD_CHUNK_SIZE_BYTES)
+                while (true) {
+                    val read = input.read(chunk)
+                    if (read < 0) break
+                    writer.write(ByteBuffer.wrap(chunk, 0, read))
+                }
             }
+        } catch (e: Exception) {
+            try {
+                writer.close()
+            } catch (closeException: Exception) {
+                logger.warn(closeException) {
+                    "Failed to close BigQuery write channel after upload error; suppressing."
+                }
+            }
+            throw e
         }
         writer.close()
         return writer.job

--- a/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/main/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertLoader.kt
@@ -7,6 +7,7 @@ package io.airbyte.integrations.destination.bigquery.write.standard_insert
 import com.google.cloud.bigquery.BigQuery
 import com.google.cloud.bigquery.BigQueryException
 import com.google.cloud.bigquery.FormatOptions
+import com.google.cloud.bigquery.Job
 import com.google.cloud.bigquery.JobId
 import com.google.cloud.bigquery.JobInfo
 import com.google.cloud.bigquery.JobStatistics
@@ -14,8 +15,8 @@ import com.google.cloud.bigquery.Schema
 import com.google.cloud.bigquery.TableDataWriteChannel
 import com.google.cloud.bigquery.TableId
 import com.google.cloud.bigquery.WriteChannelConfiguration
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
 import io.airbyte.cdk.ConfigErrorException
+import io.airbyte.cdk.TransientErrorException
 import io.airbyte.cdk.load.command.DestinationCatalog
 import io.airbyte.cdk.load.command.DestinationStream
 import io.airbyte.cdk.load.config.DataChannelFormat
@@ -41,9 +42,14 @@ import io.micronaut.context.condition.Condition
 import io.micronaut.context.condition.ConditionContext
 import jakarta.inject.Named
 import jakarta.inject.Singleton
-import java.io.ByteArrayOutputStream
+import java.io.BufferedOutputStream
+import java.io.OutputStream
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.math.min
+import kotlinx.coroutines.delay
 
 private val logger = KotlinLogging.logger {}
 
@@ -56,46 +62,39 @@ class BigqueryBatchStandardInsertsLoader(
     private val writeChannelConfiguration: WriteChannelConfiguration,
     private val job: JobId,
     private val recordFormatter: RecordFormatter,
+    private val maxUploadAttempts: Int = DEFAULT_MAX_UPLOAD_ATTEMPTS,
+    private val initialRetryDelayMs: Long = DEFAULT_INITIAL_RETRY_DELAY_MS,
+    private val maxRetryDelayMs: Long = DEFAULT_MAX_RETRY_DELAY_MS,
 ) : DirectLoader {
-    // a TableDataWriteChannel holds (by default) a 15MB buffer in memory.
-    // so we start out by writing to a BAOS, which grows dynamically.
-    // when the BAOS reaches 15MB, we create the TableDataWriteChannel and switch over
-    // to writing to the writechannel directly.
-    // invariant: either the buffer is nonnull, or the writer is initialized. They are never both
-    // active at the same time.
-    // bigquery sets daily limits on how many TableDataWriteChannel jobs you can run,
-    // so we can't just flush+close a TableDataWriteChannel as soon as we reach 15MB.
-    private var buffer: ByteArrayOutputStream? = ByteArrayOutputStream()
-    private lateinit var writer: TableDataWriteChannel
+    // Records are spilled to a local file rather than streamed straight into a
+    // TableDataWriteChannel, so that the whole batch can be re-uploaded if BigQuery's resumable
+    // upload endpoint returns a transient error partway through.
+    // bigquery sets daily limits on how many load jobs you can run, so we upload one file per
+    // batch instead of flushing a TableDataWriteChannel every few MB.
+    private val spillFile: Path = Files.createTempFile("bigquery-standard-inserts-", ".jsonl")
+    private val spillOutput: OutputStream =
+        BufferedOutputStream(Files.newOutputStream(spillFile), SPILL_BUFFER_SIZE_BYTES)
 
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
     override suspend fun accept(record: DestinationRecordRaw): DirectLoader.DirectLoadResult {
         val formattedRecord = recordFormatter.formatRecord(record)
         val byteArray =
             "$formattedRecord${System.lineSeparator()}".toByteArray(StandardCharsets.UTF_8)
-
-        if (this::writer.isInitialized) {
-            writer.write(ByteBuffer.wrap(byteArray))
-        } else {
-            buffer!!.write(byteArray)
-            // the default chunk size on the TableDataWriteChannel is 15MB,
-            // so switch to writing to a real writechannel when we reach that size
-            if (buffer!!.size() > 15 * 1024 * 1024) {
-                switchToWriteChannel()
-            }
-        }
+        spillOutput.write(byteArray)
 
         // rely on the CDK to tell us when to finish()
         return DirectLoader.Incomplete
     }
 
     override suspend fun finish() {
-        if (!this::writer.isInitialized) {
-            switchToWriteChannel()
-        }
-        writer.close()
-        BigQueryUtils.waitForJobFinish(writer.job)
-        val stats = writer.job.reload().getStatistics<JobStatistics.LoadStatistics>()
+        spillOutput.close()
+        val loadJob =
+            try {
+                uploadWithRetries()
+            } finally {
+                Files.deleteIfExists(spillFile)
+            }
+        BigQueryUtils.waitForJobFinish(loadJob)
+        val stats = loadJob.reload().getStatistics<JobStatistics.LoadStatistics>()
         logger.info {
             "Finished loading data into table ${writeChannelConfiguration.destinationTable.toPrettyString()}. ${stats.outputRows} rows loaded; ${stats.badRecords} bad records."
         }
@@ -108,26 +107,89 @@ class BigqueryBatchStandardInsertsLoader(
         }
     }
 
-    override fun close() {}
+    override fun close() {
+        spillOutput.close()
+        Files.deleteIfExists(spillFile)
+    }
 
-    // Somehow spotbugs thinks that `writer.write(ByteBuffer.wrap(byteArray))` is a redundant null
-    // check...
-    @SuppressFBWarnings(value = ["RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"])
-    private fun switchToWriteChannel() {
-        writer =
+    /**
+     * Uploads the spill file to BigQuery as a single load job, retrying on transient errors from
+     * the resumable upload endpoint.
+     *
+     * Every attempt reuses the same [JobId]. BigQuery job IDs are unique per project, so if a
+     * previous attempt's upload actually completed (and the load job was created) we detect that via
+     * [BigQuery.getJob] and wait for that job instead of re-submitting the data, which avoids
+     * duplicate loads.
+     */
+    private suspend fun uploadWithRetries(): Job {
+        var retryDelayMs = initialRetryDelayMs
+        var lastException: BigQueryException? = null
+        for (attempt in 1..maxUploadAttempts) {
+            if (attempt > 1) {
+                val existingJob = bigquery.getJob(job)
+                if (existingJob != null) {
+                    logger.info {
+                        "Load job ${job.job} already exists after a failed upload attempt; waiting for it instead of re-uploading."
+                    }
+                    return existingJob
+                }
+            }
+            try {
+                return uploadOnce()
+            } catch (e: BigQueryException) {
+                if (!isRetryableUploadError(e)) {
+                    throw e
+                }
+                lastException = e
+                logger.warn(e) {
+                    "Transient BigQuery error (HTTP ${e.code}) while uploading batch to ${writeChannelConfiguration.destinationTable.toPrettyString()} (attempt $attempt/$maxUploadAttempts). Sleeping ${retryDelayMs}ms and retrying."
+                }
+                if (attempt < maxUploadAttempts) {
+                    val withJitter = retryDelayMs + (1000 * Math.random()).toLong()
+                    delay(withJitter)
+                    retryDelayMs = min(retryDelayMs * 2, maxRetryDelayMs)
+                }
+            }
+        }
+        throw TransientErrorException(
+            "BigQuery batch upload failed with HTTP ${lastException!!.code} after $maxUploadAttempts attempts.",
+            lastException,
+        )
+    }
+
+    private fun uploadOnce(): Job {
+        val writer: TableDataWriteChannel =
             try {
                 bigquery.writer(job, writeChannelConfiguration)
             } catch (e: BigQueryException) {
                 if (e.code == HTTP_STATUS_CODE_FORBIDDEN || e.code == HTTP_STATUS_CODE_NOT_FOUND) {
                     throw ConfigErrorException(CONFIG_ERROR_MSG + e)
                 } else {
-                    throw BigQueryException(e.code, e.message)
+                    throw e
                 }
             }
-        val byteArray = buffer!!.toByteArray()
-        // please GC this object :)
-        buffer = null
-        writer.write(ByteBuffer.wrap(byteArray))
+        Files.newInputStream(spillFile).use { input ->
+            val chunk = ByteArray(UPLOAD_CHUNK_SIZE_BYTES)
+            while (true) {
+                val read = input.read(chunk)
+                if (read < 0) break
+                writer.write(ByteBuffer.wrap(chunk, 0, read))
+            }
+        }
+        writer.close()
+        return writer.job
+    }
+
+    companion object {
+        const val DEFAULT_MAX_UPLOAD_ATTEMPTS = 5
+        const val DEFAULT_INITIAL_RETRY_DELAY_MS = 5_000L
+        const val DEFAULT_MAX_RETRY_DELAY_MS = 60_000L
+        private const val SPILL_BUFFER_SIZE_BYTES = 1024 * 1024
+        private const val UPLOAD_CHUNK_SIZE_BYTES = 1024 * 1024
+        private const val HTTP_STATUS_CODE_TOO_MANY_REQUESTS = 429
+
+        fun isRetryableUploadError(e: BigQueryException): Boolean =
+            e.code >= 500 || e.code == HTTP_STATUS_CODE_TOO_MANY_REQUESTS || e.isRetryable
     }
 }
 

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertsLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertsLoaderTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.destination.bigquery.write.standard_insert
+
+import com.google.cloud.bigquery.BigQuery
+import com.google.cloud.bigquery.BigQueryException
+import com.google.cloud.bigquery.Job
+import com.google.cloud.bigquery.JobId
+import com.google.cloud.bigquery.JobStatistics
+import com.google.cloud.bigquery.JobStatus
+import com.google.cloud.bigquery.TableDataWriteChannel
+import com.google.cloud.bigquery.TableId
+import com.google.cloud.bigquery.WriteChannelConfiguration
+import io.airbyte.cdk.ConfigErrorException
+import io.airbyte.cdk.TransientErrorException
+import io.airbyte.cdk.load.message.DestinationRecordRaw
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class BigqueryBatchStandardInsertsLoaderTest {
+    private val jobId = JobId.of("test-project", "test-job")
+    private val writeChannelConfiguration =
+        WriteChannelConfiguration.newBuilder(TableId.of("project", "dataset", "table")).build()
+    private val recordFormatter = RecordFormatter { "{\"id\":1}" }
+
+    private fun successfulJob(): Job {
+        val stats = mockk<JobStatistics.LoadStatistics>()
+        every { stats.outputRows } returns 1L
+        every { stats.badRecords } returns 0L
+        val status = mockk<JobStatus>()
+        every { status.error } returns null
+        every { status.state } returns JobStatus.State.DONE
+        val job = mockk<Job>(relaxed = true)
+        every { job.jobId } returns jobId
+        every { job.status } returns status
+        every { job.waitFor(*anyVararg()) } returns job
+        every { job.reload(*anyVararg()) } returns job
+        every { job.getStatistics<JobStatistics.LoadStatistics>() } returns stats
+        return job
+    }
+
+    private fun writerThatFailsOnClose(code: Int): TableDataWriteChannel {
+        val writer = mockk<TableDataWriteChannel>()
+        every { writer.write(any<ByteBuffer>()) } answers { firstArg<ByteBuffer>().remaining() }
+        every { writer.close() } throws BigQueryException(code, "boom")
+        return writer
+    }
+
+    private fun successfulWriter(job: Job, captured: StringBuilder): TableDataWriteChannel {
+        val writer = mockk<TableDataWriteChannel>()
+        every { writer.write(any<ByteBuffer>()) } answers
+            {
+                val buf = firstArg<ByteBuffer>()
+                val bytes = ByteArray(buf.remaining())
+                buf.get(bytes)
+                captured.append(String(bytes, StandardCharsets.UTF_8))
+                bytes.size
+            }
+        every { writer.close() } returns Unit
+        every { writer.job } returns job
+        return writer
+    }
+
+    private fun loader(bigquery: BigQuery) =
+        BigqueryBatchStandardInsertsLoader(
+            bigquery,
+            writeChannelConfiguration,
+            jobId,
+            recordFormatter,
+            maxUploadAttempts = 3,
+            initialRetryDelayMs = 1,
+            maxRetryDelayMs = 1,
+        )
+
+    @Test
+    fun `retries the whole batch after a transient 500 on upload`() = runBlocking {
+        val job = successfulJob()
+        val uploaded = StringBuilder()
+        val bigquery = mockk<BigQuery>()
+        every { bigquery.writer(jobId, writeChannelConfiguration) } returnsMany
+            listOf(writerThatFailsOnClose(500), successfulWriter(job, uploaded))
+        every { bigquery.getJob(jobId) } returns null
+
+        val loader = loader(bigquery)
+        loader.accept(mockk<DestinationRecordRaw>())
+        loader.accept(mockk<DestinationRecordRaw>())
+        loader.finish()
+
+        verify(exactly = 2) { bigquery.writer(jobId, writeChannelConfiguration) }
+        assertEquals(
+            "{\"id\":1}${System.lineSeparator()}{\"id\":1}${System.lineSeparator()}",
+            uploaded.toString(),
+        )
+    }
+
+    @Test
+    fun `reuses the existing load job instead of re-uploading`() = runBlocking {
+        val job = successfulJob()
+        val bigquery = mockk<BigQuery>()
+        every { bigquery.writer(jobId, writeChannelConfiguration) } returns
+            writerThatFailsOnClose(503)
+        every { bigquery.getJob(jobId) } returns job
+
+        val loader = loader(bigquery)
+        loader.accept(mockk<DestinationRecordRaw>())
+        loader.finish()
+
+        verify(exactly = 1) { bigquery.writer(jobId, writeChannelConfiguration) }
+    }
+
+    @Test
+    fun `gives up with a transient error after exhausting attempts`() = runBlocking {
+        val bigquery = mockk<BigQuery>()
+        every { bigquery.writer(jobId, writeChannelConfiguration) } returns
+            writerThatFailsOnClose(500)
+        every { bigquery.getJob(jobId) } returns null
+
+        val loader = loader(bigquery)
+        loader.accept(mockk<DestinationRecordRaw>())
+        assertThrows(TransientErrorException::class.java) {
+            runBlocking { loader.finish() }
+        }
+
+        verify(exactly = 3) { bigquery.writer(jobId, writeChannelConfiguration) }
+    }
+
+    @Test
+    fun `does not retry non-transient errors`() = runBlocking {
+        val bigquery = mockk<BigQuery>()
+        every { bigquery.writer(jobId, writeChannelConfiguration) } returns
+            writerThatFailsOnClose(400)
+
+        val loader = loader(bigquery)
+        loader.accept(mockk<DestinationRecordRaw>())
+        val e =
+            assertThrows(BigQueryException::class.java) {
+                runBlocking { loader.finish() }
+            }
+        assertEquals(400, e.code)
+
+        verify(exactly = 1) { bigquery.writer(jobId, writeChannelConfiguration) }
+    }
+
+    @Test
+    fun `maps 403 on writer creation to a config error`() = runBlocking {
+        val bigquery = mockk<BigQuery>()
+        every { bigquery.writer(jobId, writeChannelConfiguration) } throws
+            BigQueryException(403, "forbidden")
+
+        val loader = loader(bigquery)
+        loader.accept(mockk<DestinationRecordRaw>())
+        assertThrows(ConfigErrorException::class.java) {
+            runBlocking { loader.finish() }
+        }
+    }
+}

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertsLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertsLoaderTest.kt
@@ -126,9 +126,7 @@ class BigqueryBatchStandardInsertsLoaderTest {
 
         val loader = loader(bigquery)
         loader.accept(mockk<DestinationRecordRaw>())
-        assertThrows(TransientErrorException::class.java) {
-            runBlocking { loader.finish() }
-        }
+        assertThrows(TransientErrorException::class.java) { runBlocking { loader.finish() } }
 
         verify(exactly = 3) { bigquery.writer(jobId, writeChannelConfiguration) }
     }
@@ -141,10 +139,7 @@ class BigqueryBatchStandardInsertsLoaderTest {
 
         val loader = loader(bigquery)
         loader.accept(mockk<DestinationRecordRaw>())
-        val e =
-            assertThrows(BigQueryException::class.java) {
-                runBlocking { loader.finish() }
-            }
+        val e = assertThrows(BigQueryException::class.java) { runBlocking { loader.finish() } }
         assertEquals(400, e.code)
 
         verify(exactly = 1) { bigquery.writer(jobId, writeChannelConfiguration) }
@@ -158,8 +153,6 @@ class BigqueryBatchStandardInsertsLoaderTest {
 
         val loader = loader(bigquery)
         loader.accept(mockk<DestinationRecordRaw>())
-        assertThrows(ConfigErrorException::class.java) {
-            runBlocking { loader.finish() }
-        }
+        assertThrows(ConfigErrorException::class.java) { runBlocking { loader.finish() } }
     }
 }

--- a/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertsLoaderTest.kt
+++ b/airbyte-integrations/connectors/destination-bigquery/src/test/kotlin/io/airbyte/integrations/destination/bigquery/write/standard_insert/BigqueryBatchStandardInsertsLoaderTest.kt
@@ -30,7 +30,10 @@ class BigqueryBatchStandardInsertsLoaderTest {
     private val jobId = JobId.of("test-project", "test-job")
     private val writeChannelConfiguration =
         WriteChannelConfiguration.newBuilder(TableId.of("project", "dataset", "table")).build()
-    private val recordFormatter = RecordFormatter { "{\"id\":1}" }
+    private val recordFormatter =
+        object : RecordFormatter {
+            override fun formatRecord(record: DestinationRecordRaw): String = "{\"id\":1}"
+        }
 
     private fun successfulJob(): Job {
         val stats = mockk<JobStatistics.LoadStatistics>()

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -280,6 +280,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.1.2 | 2026-09-09 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Retry transient BigQuery errors when uploading batched standard-insert load jobs, instead of failing the sync. |
 | 3.1.1 | 2026-09-09 | [79178](https://github.com/airbytehq/airbyte/pull/79178) | Classify BigQuery custom quota exceeded errors as config errors instead of system errors. |
 | 3.1.0 | 2026-08-25 | [85041](https://github.com/airbytehq/airbyte/pull/85041) | Add optional `job_project_id` field for BigQuery job quota isolation |
 | 3.0.24 | 2026-08-24 | [84985](https://github.com/airbytehq/airbyte/pull/84985) | Upgrade to Bulk CDK 1.0.25. |

--- a/docs/integrations/destinations/bigquery.md
+++ b/docs/integrations/destinations/bigquery.md
@@ -280,7 +280,7 @@ This destination supports [namespaces](https://docs.airbyte.com/platform/using-a
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                                                           |
 |:------------|:-----------|:-----------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.1.2 | 2026-09-09 | [PR_NUMBER](https://github.com/airbytehq/airbyte/pull/PR_NUMBER) | Retry transient BigQuery errors when uploading batched standard-insert load jobs, instead of failing the sync. |
+| 3.1.2 | 2026-09-09 | [85787](https://github.com/airbytehq/airbyte/pull/85787) | Retry transient BigQuery errors when uploading batched standard-insert load jobs, instead of failing the sync. |
 | 3.1.1 | 2026-09-09 | [79178](https://github.com/airbytehq/airbyte/pull/79178) | Classify BigQuery custom quota exceeded errors as config errors instead of system errors. |
 | 3.1.0 | 2026-08-25 | [85041](https://github.com/airbytehq/airbyte/pull/85041) | Add optional `job_project_id` field for BigQuery job quota isolation |
 | 3.0.24 | 2026-08-24 | [84985](https://github.com/airbytehq/airbyte/pull/84985) | Upgrade to Bulk CDK 1.0.25. |


### PR DESCRIPTION
## What

<table><tr><td>

**:point_right: TL;DR:** The BigQuery destination's "batched standard inserts" loading method now retries a batch upload when BigQuery returns a transient error (500/503/429) partway through, instead of failing the whole sync attempt.

`BigqueryBatchStandardInsertsLoader` spills each batch to a local file and re-uploads it with exponential backoff, reusing the same `JobId` so a retry can never double-load a batch.

</td></tr></table>

Fixes airbytehq/oncall#13414 (internal). On multi-GB streams each attempt performs hundreds of 15 MB resumable-upload chunk `PUT`s; a single `500 internalError` on any of them escaped `finish()` as a `system_error` and killed the attempt, so large streams failed on every retry while small streams synced fine. The Google client does not retry this path (`TableDataWriteChannel.flushBuffer` uses an empty retry config), and the loader streamed records straight into the channel so there was nothing left to re-send.

Requested by Sunil Kuruba.

## How

- Records are written to a buffered temp file (`Files.createTempFile`) instead of a 15 MB in-memory buffer + live `TableDataWriteChannel`.
- `finish()` calls `uploadWithRetries()`:
  - creates a fresh `TableDataWriteChannel`, streams the file into it in 1 MB chunks, closes it
  - on `BigQueryException` with `code >= 500`, `429`, or `isRetryable`, sleeps (5s, ×2, capped at 60s, +jitter) and retries, up to 5 attempts
  - before each retry, checks `bigquery.getJob(jobId)`: if the previous attempt's upload actually completed and created the load job, waits on that job instead of re-uploading (job IDs are unique per project, so this makes the retry idempotent)
  - after exhausting attempts throws `TransientErrorException` (surfaces as `transient_error` instead of `system_error`)
- Non-retryable errors are rethrown unchanged; 403/404 on channel creation still map to `ConfigErrorException`.
- Temp file is deleted in `finally` / `close()`.
- Bumps to `3.1.2` with changelog entry.

## Review guide

1. `BigqueryBatchStandardInsertLoader.kt` — `uploadWithRetries` / `uploadOnce` / `isRetryableUploadError`
2. `BigqueryBatchStandardInsertsLoaderTest.kt` — mockk tests for retry, job reuse, exhaustion, non-retryable, 403

## User Impact

- Large streams using batched standard inserts no longer fail on a single transient BigQuery 5xx; the batch is retried.
- If BigQuery keeps failing, the error is reported as `transient_error` (platform will retry) rather than `system_error`.
- Trade-off: each in-flight batch is now buffered on local disk (previously up to 15 MB in memory, then streamed). Disk usage per batch equals the batch size; the GCS staging loading method already writes batches to local disk in the same way.

## Test plan

- Added `BigqueryBatchStandardInsertsLoaderTest` (unit, mockk). I could not run it locally: Gradle dependency resolution in this sandbox is rate-limited by Maven Central (`429 Too Many Requests` on plugin classpath), so compilation and tests are pending CI.
- Integration tests (`destination-bigquery` standard-inserts suites) should exercise the happy path unchanged.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/e10c38da77cc44d9b86f76cba25d5749
Open in Devin Desktop: https://app.devin.ai/desktop/session/e10c38da77cc44d9b86f76cba25d5749?variant=devin
Requested by: @sunil-kuruba

> [!IMPORTANT]
> Active progressive rollout warning for destination-bigquery.

- [ ] (Click to Approve:) Bypass the active progressive rollout warning for destination-bigquery in the PR comment [here](https://github.com/airbytehq/airbyte/pull/85787#issuecomment-5609065965).

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.