### PR TITLE
fix(source-github): clarify 401 and 404 error messages

### DIFF
--- a/airbyte-integrations/connectors/source-github/source_github/errors_handlers.py
+++ b/airbyte-integrations/connectors/source-github/source_github/errors_handlers.py
@@ -22,7 +22,11 @@ GITHUB_DEFAULT_ERROR_MAPPING = DEFAULT_ERROR_MAPPING | {
     401: ErrorResolution(
         response_action=ResponseAction.RETRY,
         failure_type=FailureType.config_error,
-        error_message="Conflict.",
+        error_message=(
+            "GitHub authentication failed (HTTP 401). "
+            "The configured Personal Access Token or OAuth credentials may be expired, revoked, "
+            "or missing required scopes. Please verify or renew your credentials."
+        ),
     ),
     403: ErrorResolution(
         response_action=ResponseAction.FAIL,
@@ -37,7 +41,10 @@ GITHUB_DEFAULT_ERROR_MAPPING = DEFAULT_ERROR_MAPPING | {
     404: ErrorResolution(
         response_action=ResponseAction.RETRY,
         failure_type=FailureType.config_error,
-        error_message="Conflict.",
+        error_message=(
+            "GitHub resource not found (HTTP 404). "
+            "The repository or organization may not exist, may be private, or the token may lack access to it."
+        ),
     ),
     409: ErrorResolution(
         response_action=ResponseAction.RETRY,

--- a/airbyte-integrations/connectors/source-github/unit_tests/test_stream.py
+++ b/airbyte-integrations/connectors/source-github/unit_tests/test_stream.py
@@ -227,6 +227,50 @@ def test_permission_403_fails_immediately():
     assert "SAML SSO authorization" in result.error_message
 
 
+def test_authentication_401_retries_with_actionable_message():
+    """
+    Verify that a 401 Unauthorized response results in ResponseAction.RETRY
+    and returns an actionable authentication error message rather than 'Conflict.'.
+    """
+    stream = RepositoryStats(repositories=["test_repo"], page_size_for_large_streams=30)
+    response_mock = MagicMock(spec=requests.Response)
+    response_mock.status_code = HTTPStatus.UNAUTHORIZED
+    response_mock.headers = {}
+    response_mock.text = '{"message": "Bad credentials"}'
+    response_mock.ok = False
+    response_mock.json = lambda: json.loads(response_mock.text)
+
+    result = stream.get_error_handler().interpret_response(response_mock)
+    assert result.response_action == ResponseAction.RETRY
+    assert result.failure_type == FailureType.config_error
+    assert "GitHub authentication failed (HTTP 401)" in result.error_message
+    assert "expired" in result.error_message
+    assert "revoked" in result.error_message
+    assert "missing required scopes" in result.error_message
+    assert "renew" in result.error_message
+    assert "Conflict." not in result.error_message
+
+
+def test_resource_not_found_404_retries_with_actionable_message():
+    """
+    Verify that a 404 Not Found response results in ResponseAction.RETRY
+    and returns an actionable resource not found message rather than 'Conflict.'.
+    """
+    stream = RepositoryStats(repositories=["test_repo"], page_size_for_large_streams=30)
+    response_mock = MagicMock(spec=requests.Response)
+    response_mock.status_code = HTTPStatus.NOT_FOUND
+    response_mock.headers = {}
+    response_mock.text = '{"message": "Not Found"}'
+    response_mock.ok = False
+    response_mock.json = lambda: json.loads(response_mock.text)
+
+    result = stream.get_error_handler().interpret_response(response_mock)
+    assert result.response_action == ResponseAction.RETRY
+    assert result.failure_type == FailureType.config_error
+    assert "GitHub resource not found (HTTP 404)" in result.error_message
+    assert "Conflict." not in result.error_message
+
+
 @pytest.mark.parametrize(
     ("response_headers",),
     [


### PR DESCRIPTION
## What

In `source-github`, HTTP 401 (Unauthorized) and HTTP 404 (Not Found) responses were surfacing the misleading user-facing message `"Conflict."` from the shared error mapping. This obscures authentication failures and missing or inaccessible resources as conflicts.

Fixes #85256

## How

* Updates the HTTP 401 message to explain that credentials may be expired, revoked, or missing required scopes and recommends verifying or renewing them.
* Updates the HTTP 404 message to explain that the repository or organization may not exist, may be private, or the token may lack access.
* Preserves existing `ResponseAction.RETRY` and `FailureType.config_error` behavior.
* Leaves the HTTP 409 `"Conflict."` behavior unchanged.
* Adds focused regression tests for the 401 and 404 mappings.

## Review guide

1. `airbyte-integrations/connectors/source-github/source_github/errors_handlers.py` — updated 401 and 404 mappings.
2. `airbyte-integrations/connectors/source-github/unit_tests/test_stream.py` — focused regression coverage.

## User Impact

GitHub 401 and 404 failures will now surface actionable error context rather than the misleading `"Conflict."` message.

## Can this PR be safely reverted and rolled back?

* [x] YES 💚
* [ ] NO ❌
