### PR TITLE
chore(destination-snowflake): run integration tests on `master` (do not merge)

### DIFF
--- a/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeBeanFactory.kt
+++ b/airbyte-integrations/connectors/destination-snowflake/src/main/kotlin/io/airbyte/integrations/destination/snowflake/SnowflakeBeanFactory.kt
@@ -53,6 +53,7 @@ internal const val DATA_SOURCE_PROPERTY_TRACING = "tracing"
 internal const val DATA_SOURCE_PROPERTY_WAREHOUSE = "warehouse"
 internal const val JSON_FORMAT = "JSON"
 internal const val NETWORK_TIMEOUT_MINUTES: Long = 1L
+/** Relative to the process working directory. */
 internal const val PRIVATE_KEY_FILE_NAME: String = "rsa_key.p8"
 
 @Factory


### PR DESCRIPTION
## Overview

<table><tr><td>

**:point_right: TL;DR:** Research PR (do not merge) to check whether the `destination-snowflake` integration tests currently pass on plain `master`, independently of #84953.

The only diff is a one-line comment on `PRIVATE_KEY_FILE_NAME` in `SnowflakeBeanFactory.kt`, enough to trigger the connector CI.

</td></tr></table>

Pairs with #84953:
- #84953

## What

#84953 reports 89 `destination-snowflake` integration-test failures. This PR runs the same suite against `master` (`73b537c0c37` + a comment) so the results can be compared. Requested by Rodi Reich (@rodireich).

## How

Comment-only change in `SnowflakeBeanFactory.kt` to trigger the `destination-snowflake` connector test workflow.

## Review guide

Nothing to review; look at the `destination-snowflake` Connector Test Results check.

## User Impact

None. Not intended for merge.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌


Link to Devin session: https://app.devin.ai/sessions/deb6556d7f6547b48ebe5b5f629dee4d
Open in Devin Desktop: https://app.devin.ai/desktop/session/deb6556d7f6547b48ebe5b5f629dee4d?variant=devin

---

> [!IMPORTANT]
> **Autopilot Progressive Rollout Enabled**
>
> [Autopilot progressive rollouts](https://github.com/airbytehq/airbyte-ops-mcp/blob/main/docs/autopilot-rollouts.md) are enabled for one or more connector(s) modified in this PR. Check the box below if you need to bypass normal rollout safety processes and release to all users immediately upon merge:
>
> - [ ] ⚡ **Release immediately** (bypasses automatic progressive rollout)
>
> **Note:**
>
> - ⚠️ The above bypass option is for emergency/hotfix use only.
> - 🔗 You can monitor or manually advance a rollout at **[ops.internal.airbyte.ai](https://ops.internal.airbyte.ai)**.