### PR TITLE
feat(source-zoho-crm): add advanced_auth with declarative OAuth

### DIFF
--- a/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
+++ b/airbyte-integrations/connectors/source-zoho-crm/metadata.yaml
@@ -7,7 +7,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 4942d392-c7b5-4271-91f9-3b4f4e51eb3e
-  dockerImageTag: 0.1.5
+  dockerImageTag: 0.2.0
   dockerRepository: airbyte/source-zoho-crm
   documentationUrl: https://docs.airbyte.com/integrations/sources/zoho-crm
   githubIssueLabel: source-zoho-crm

--- a/airbyte-integrations/connectors/source-zoho-crm/pyproject.toml
+++ b/airbyte-integrations/connectors/source-zoho-crm/pyproject.toml
@@ -3,7 +3,7 @@ requires = [ "poetry-core>=1.0.0",]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-version = "0.1.5"
+version = "0.2.0"
 name = "source-zoho-crm"
 description = "Source implementation for <<Name>>."
 authors = [ "Airbyte <contact@airbyte.io>",]

--- a/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/spec.json
+++ b/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/spec.json
@@ -70,7 +70,10 @@
     "auth_flow_type": "oauth2.0",
     "oauth_config_specification": {
       "oauth_connector_input_specification": {
-        "scopes": [{ "scope": "ZohoCRM.settings.READ" }, { "scope": "ZohoCRM.modules.READ" }],
+        "scopes": [
+          { "scope": "ZohoCRM.settings.READ" },
+          { "scope": "ZohoCRM.modules.READ" }
+        ],
         "scopes_join_strategy": "comma",
         "consent_url": "https://accounts.zoho.{{ {'US': 'com', 'AU': 'com.au', 'EU': 'eu', 'IN': 'in', 'CN': 'com.cn', 'JP': 'jp'}[dc_region] }}/oauth/v2/auth?response_type=code&access_type=offline&prompt=consent&{{client_id_param}}&{{redirect_uri_param}}&{{scopes_param}}&{{state_param}}",
         "access_token_url": "https://accounts.zoho.{{ {'US': 'com', 'AU': 'com.au', 'EU': 'eu', 'IN': 'in', 'CN': 'com.cn', 'JP': 'jp'}[dc_region] }}/oauth/v2/token?grant_type=authorization_code&{{client_id_param}}&{{client_secret_param}}&{{auth_code_param}}&{{redirect_uri_param}}",

--- a/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/spec.json
+++ b/airbyte-integrations/connectors/source-zoho-crm/source_zoho_crm/spec.json
@@ -65,5 +65,59 @@
         "default": "Free"
       }
     }
+  },
+  "advanced_auth": {
+    "auth_flow_type": "oauth2.0",
+    "oauth_config_specification": {
+      "oauth_connector_input_specification": {
+        "scopes": [{ "scope": "ZohoCRM.settings.READ" }, { "scope": "ZohoCRM.modules.READ" }],
+        "scopes_join_strategy": "comma",
+        "consent_url": "https://accounts.zoho.{{ {'US': 'com', 'AU': 'com.au', 'EU': 'eu', 'IN': 'in', 'CN': 'com.cn', 'JP': 'jp'}[dc_region] }}/oauth/v2/auth?response_type=code&access_type=offline&prompt=consent&{{client_id_param}}&{{redirect_uri_param}}&{{scopes_param}}&{{state_param}}",
+        "access_token_url": "https://accounts.zoho.{{ {'US': 'com', 'AU': 'com.au', 'EU': 'eu', 'IN': 'in', 'CN': 'com.cn', 'JP': 'jp'}[dc_region] }}/oauth/v2/token?grant_type=authorization_code&{{client_id_param}}&{{client_secret_param}}&{{auth_code_param}}&{{redirect_uri_param}}",
+        "extract_output": ["refresh_token"]
+      },
+      "oauth_user_input_from_connector_config_specification": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "dc_region": {
+            "type": "string",
+            "path_in_connector_config": ["dc_region"]
+          }
+        }
+      },
+      "complete_oauth_output_specification": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "refresh_token": {
+            "type": "string",
+            "path_in_connector_config": ["refresh_token"]
+          }
+        }
+      },
+      "complete_oauth_server_input_specification": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "client_id": { "type": "string" },
+          "client_secret": { "type": "string" }
+        }
+      },
+      "complete_oauth_server_output_specification": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "client_id": {
+            "type": "string",
+            "path_in_connector_config": ["client_id"]
+          },
+          "client_secret": {
+            "type": "string",
+            "path_in_connector_config": ["client_secret"]
+          }
+        }
+      }
+    }
   }
 }

--- a/airbyte-integrations/connectors/source-zoho-crm/unit_tests/test_spec.py
+++ b/airbyte-integrations/connectors/source-zoho-crm/unit_tests/test_spec.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+#
+
+"""Tests for the ``advanced_auth`` (declarative OAuth) block in ``spec.json``.
+
+The platform's DeclarativeOAuthFlow builds the consent and token URLs from the
+spec, substituting ``dc_region`` from the user's config. These tests pin the
+contract: every data center selectable in the connection spec must resolve to a
+Zoho accounts domain in both OAuth URLs, and every OAuth output path must point
+at a real connection-spec property.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+SPEC = json.loads((Path(__file__).parent.parent / "source_zoho_crm" / "spec.json").read_text())
+CONNECTION_PROPERTIES = SPEC["connectionSpecification"]["properties"]
+OAUTH_SPEC = SPEC["advanced_auth"]["oauth_config_specification"]
+CONNECTOR_INPUT = OAUTH_SPEC["oauth_connector_input_specification"]
+
+# Domains documented at https://www.zoho.com/crm/developer/docs/api/v2/multi-dc.html
+DC_REGION_TO_ACCOUNTS_DOMAIN = {
+    "US": "com",
+    "AU": "com.au",
+    "EU": "eu",
+    "IN": "in",
+    "CN": "com.cn",
+    "JP": "jp",
+}
+
+
+def test_auth_flow_type_is_oauth2():
+    assert SPEC["advanced_auth"]["auth_flow_type"] == "oauth2.0"
+
+
+@pytest.mark.parametrize("url_key", ["consent_url", "access_token_url"])
+def test_oauth_urls_map_every_dc_region(url_key):
+    """The inline Jinja mapping in each OAuth URL must cover every ``dc_region`` enum value."""
+    template = CONNECTOR_INPUT[url_key]
+    mapping_literal = re.search(r"\{\{\s*(\{[^}]*\})\[dc_region\]\s*\}\}", template)
+    assert mapping_literal, f"{url_key} must map dc_region to a Zoho accounts domain"
+    mapping = json.loads(mapping_literal.group(1).replace("'", '"'))
+
+    dc_region_enum = set(CONNECTION_PROPERTIES["dc_region"]["enum"])
+    assert set(mapping) == dc_region_enum, f"{url_key} mapping must cover exactly the dc_region enum values"
+    assert mapping == DC_REGION_TO_ACCOUNTS_DOMAIN
+
+
+def test_consent_url_requests_offline_access():
+    """Zoho only returns a refresh token when offline access and consent are requested."""
+    consent_url = CONNECTOR_INPUT["consent_url"]
+    assert "access_type=offline" in consent_url
+    assert "prompt=consent" in consent_url
+
+
+def test_scopes_cover_connector_endpoints_and_join_with_comma():
+    """The connector reads settings (modules/fields) and module records; Zoho separates scopes with commas."""
+    scopes = {entry["scope"] for entry in CONNECTOR_INPUT["scopes"]}
+    assert scopes == {"ZohoCRM.settings.READ", "ZohoCRM.modules.READ"}
+    assert CONNECTOR_INPUT["scopes_join_strategy"] == "comma"
+
+
+def test_oauth_paths_exist_in_connection_spec():
+    """Every path_in_connector_config must target a property the connection spec declares."""
+    sections = [
+        OAUTH_SPEC["oauth_user_input_from_connector_config_specification"],
+        OAUTH_SPEC["complete_oauth_output_specification"],
+        OAUTH_SPEC["complete_oauth_server_output_specification"],
+    ]
+    for section in sections:
+        for name, prop in section["properties"].items():
+            path = prop["path_in_connector_config"]
+            assert path == [name], f"{name} must map to the top-level spec property of the same name"
+            assert name in CONNECTION_PROPERTIES, f"{name} is not a connection spec property"
+
+
+def test_extract_output_is_refresh_token_only():
+    """Zoho's token response is exchanged for a long-lived refresh token; nothing else persists."""
+    assert CONNECTOR_INPUT["extract_output"] == ["refresh_token"]

--- a/docs/integrations/sources/zoho-crm.md
+++ b/docs/integrations/sources/zoho-crm.md
@@ -182,6 +182,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
+| 0.2.0 | 2026-09-11 | [85833](https://github.com/airbytehq/airbyte/pull/85833) | Add `advanced_auth` with declarative OAuth (data-center-aware consent and token URLs) |
 | 0.1.5 | 2026-08-25 | [79062](https://github.com/airbytehq/airbyte/pull/79062) | Update dependencies |
 | 0.1.4 | 2026-08-24 | [80278](https://github.com/airbytehq/airbyte/pull/80278) | Fix incremental sync: tolerate `Z`-suffixed (UTC) cursor values and resolve cursor field per module instead of hardcoding `Modified_Time` |
 | 0.1.3 | 2025-02-05 | [42864](https://github.com/airbytehq/airbyte/pull/42864) | Migrate to Poetry |

--- a/docs/integrations/sources/zoho-crm.md
+++ b/docs/integrations/sources/zoho-crm.md
@@ -180,7 +180,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 <details>
   <summary>Expand to review</summary>
 
-| Version | Date       | Pull Request                                             | Subject                                                                                                                                   |
+| Version | Date | Pull Request | Subject |
 | :------ | :--------- | :------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------- |
 | 0.2.0 | 2026-09-11 | [85833](https://github.com/airbytehq/airbyte/pull/85833) | Add `advanced_auth` with declarative OAuth (data-center-aware consent and token URLs) |
 | 0.1.5 | 2026-08-25 | [79062](https://github.com/airbytehq/airbyte/pull/79062) | Update dependencies |


### PR DESCRIPTION
## What

Adds an `advanced_auth` block (declarative OAuth) to `source-zoho-crm`, so platforms that support hosted OAuth can render a sign-in button instead of asking users to paste a Client ID, Client Secret and Refresh Token by hand.

## How

The spec now declares `oauth_config_specification` with a declarative `oauth_connector_input_specification`. Zoho hosts a separate accounts server per data center, so both the consent URL and the token URL resolve the domain from the user's `dc_region` config value through an inline Jinja mapping (US -> com, AU -> com.au, EU -> eu, IN -> in, CN -> com.cn, JP -> jp), following the same user-input templating pattern as `source-zendesk-chat`. The consent URL requests `access_type=offline` and `prompt=consent`, which Zoho requires to issue a refresh token, and scopes are joined with commas per Zoho's format. The flow persists only the refresh token; client id and secret come from the instance-wide OAuth app. Scopes are the four read scopes Zoho documents for the endpoints the connector calls: `ZohoCRM.settings.modules.READ` (`/crm/v2/settings/modules`), `ZohoCRM.settings.fields.READ` (`/crm/v2/settings/fields`), `ZohoCRM.modules.READ` for record reads, and `ZohoCRM.modules.custom.READ` because the connector also syncs custom modules, which Zoho scopes separately. Zoho has no bare `ZohoCRM.settings.READ`, and `modules.READ` is requested instead of `modules.ALL` to keep the grant read-only. The docs setup guide now describes both paths: the OAuth button on Cloud and manual credentials for OSS or a self-owned Zoho app, with the same scope list.

Existing configs are untouched: the connection specification itself is unchanged, and manual credential entry keeps working. Version bumped to 0.2.0.

New unit tests pin the contract: every `dc_region` enum value must resolve to the documented Zoho accounts domain in both OAuth URLs, offline access must be requested, and every OAuth output path must target a real connection-spec property.