### PR TITLE
fix(source-postgres): preserve row and commit LSNs in CDC progress comparisons

### DIFF
--- a/airbyte-integrations/connectors/source-postgres/metadata.yaml
+++ b/airbyte-integrations/connectors/source-postgres/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: decd338e-5647-4c0b-adf4-da0e75f5a750
-  dockerImageTag: 3.8.5
+  dockerImageTag: 3.8.6
   dockerRepository: airbyte/source-postgres
   documentationUrl: https://docs.airbyte.com/integrations/sources/postgres
   githubIssueLabel: source-postgres

--- a/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/cdc/PostgresSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/main/kotlin/io/airbyte/integrations/source/postgres/cdc/PostgresSourceDebeziumOperations.kt
@@ -414,6 +414,9 @@ class PostgresSourceDebeziumOperations(
     override fun position(sourceRecord: SourceRecord): PostgresSourceCdcPosition? {
         val lsn = sourceRecord.sourceOffset()[LSN] as Long?
         val lsnCommit = sourceRecord.sourceOffset()[LSN_COMMIT] as Long?
-        return PostgresSourceCdcPosition(Lsn.valueOf(lsn), Lsn.valueOf(lsnCommit))
+        return PostgresSourceCdcPosition(
+            lsnCommit = Lsn.valueOf(lsnCommit),
+            lsn = Lsn.valueOf(lsn),
+        )
     }
 }

--- a/airbyte-integrations/connectors/source-postgres/src/test/kotlin/io/airbyte/integrations/source/postgres/cdc/PostgresSourceDebeziumOperationsTest.kt
+++ b/airbyte-integrations/connectors/source-postgres/src/test/kotlin/io/airbyte/integrations/source/postgres/cdc/PostgresSourceDebeziumOperationsTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.postgres.cdc
+
+import io.airbyte.cdk.read.cdc.DebeziumOffset
+import io.airbyte.cdk.util.Jsons
+import io.debezium.connector.postgresql.connection.Lsn
+import io.mockk.mockk
+import org.apache.kafka.connect.source.SourceRecord
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PostgresSourceDebeziumOperationsTest {
+    private val operations =
+        PostgresSourceDebeziumOperations(
+            config = mockk(),
+            connectionFactory = mockk(),
+            replicationSlotManager = mockk(),
+            startupState = null,
+        )
+
+    @Test
+    fun `source record position preserves row and commit LSNs`() {
+        val position = operations.position(sourceRecord(lsn = 100L, lsnCommit = 200L))!!
+
+        assertEquals(Lsn.valueOf(200L), position.lsnCommit)
+        assertEquals(Lsn.valueOf(100L), position.lsn)
+        assertEquals(
+            PostgresSourceDebeziumOperations.position(
+                DebeziumOffset(
+                    mapOf(
+                        Jsons.objectNode() to
+                            Jsons.objectNode().put("lsn", 100L).put("lsn_commit", 200L)
+                    )
+                )
+            ),
+            position,
+        )
+    }
+
+    @Test
+    fun `commit progress takes precedence over a decreasing row LSN`() {
+        val previous = operations.position(sourceRecord(lsn = 190L, lsnCommit = 200L))!!
+        val current = operations.position(sourceRecord(lsn = 110L, lsnCommit = 300L))!!
+
+        assertTrue(current.compareTo(previous)!! > 0)
+    }
+
+    @Test
+    fun `source record position uses row LSN to break a commit LSN tie`() {
+        val current = operations.position(sourceRecord(lsn = 110L, lsnCommit = 200L))!!
+        val previous =
+            PostgresSourceCdcPosition(lsnCommit = Lsn.valueOf(200L), lsn = Lsn.valueOf(100L))
+
+        assertTrue(current.compareTo(previous)!! > 0)
+    }
+
+    @Test
+    fun `missing commit LSN leaves progress indeterminate`() {
+        val current = operations.position(sourceRecord(lsn = 110L, lsnCommit = null))!!
+        val previous =
+            PostgresSourceCdcPosition(lsnCommit = Lsn.valueOf(200L), lsn = Lsn.valueOf(100L))
+
+        assertNull(current.lsnCommit)
+        assertEquals(Lsn.valueOf(110L), current.lsn)
+        assertNull(current.compareTo(previous))
+    }
+
+    private fun sourceRecord(lsn: Long, lsnCommit: Long?): SourceRecord =
+        SourceRecord(
+            emptyMap<String, Any>(),
+            buildMap {
+                put("lsn", lsn)
+                if (lsnCommit != null) put("lsn_commit", lsnCommit)
+            },
+            "test-topic",
+            null,
+            null,
+        )
+}

--- a/docs/integrations/sources/postgres.md
+++ b/docs/integrations/sources/postgres.md
@@ -363,6 +363,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version | Date       | Pull Request                                             | Subject                                                                                                                                                                    |
 |---------|------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.8.6   | 2026-09-11 | [85849](https://github.com/airbytehq/airbyte/pull/85849) | Preserve row and commit LSNs in CDC progress comparisons. |
 | 3.8.5   | 2026-07-29 | [82773](https://github.com/airbytehq/airbyte/pull/82773) | Fix ClassCastException when an interval column has a default value during CDC.                                                                                             |
 | 3.8.4   | 2026-07-28 | [79110](https://github.com/airbytehq/airbyte/pull/79110) | Fix PostGIS geometry/geography columns returning NULL on CDC path. Values now always use hex-WEKB format, for both CDC and snapshots.                                      |
 | 3.8.3   | 2026-07-27 | [82782](https://github.com/airbytehq/airbyte/pull/82782) | Remove the non-functional `invalid_cdc_cursor_position_behavior` option; invalidated replication slots always fail the sync.                                               |


### PR DESCRIPTION
## What

`position(SourceRecord)` passes the row LSN into `lsnCommit` and the commit LSN into `lsn`. Since the position comparator orders by commit LSN first, this can make a later commit appear to precede an earlier position when the row LSN decreases.

Fixes #85848.

## How

Use named constructor arguments to preserve the two offset fields. Add four regression tests covering distinct row/commit values, consistency with the saved-offset builder, commit progress despite a decreasing row LSN, the row-LSN tie-breaker, and an absent commit LSN. Propose patch version 3.8.6.

## Review guide

- `PostgresSourceDebeziumOperations.kt`: the change is confined to `position(SourceRecord)`.
- `PostgresSourceDebeziumOperationsTest.kt`: tests use real Kafka `SourceRecord` objects and synthetic offsets; only unused constructor dependencies are mocked.

## Validation

All four new tests failed on the original implementation. With the fix, all 194 tests in the following selected classes passed, with no skips:

```sh
./gradlew :airbyte-integrations:connectors:source-postgres:test \
  --tests '*PostgresSourceDebeziumOperationsTest' \
  --tests '*PostgresCustomConverterTest' \
  --tests '*PostgresSourceFieldTypeMapperTest' \
  --tests '*PostgresSourceJdbcPartitionFactoryTest' \
  --no-scan --console=plain --max-workers=4
```

`./gradlew :airbyte-integrations:connectors:source-postgres:check -x test --no-scan --console=plain --max-workers=4` also passed. The changed Kotlin files were formatted with the repository's Spotless configuration.

The regression tests validate position construction and comparison, not a complete CDC sync or the cause of a particular incident.

## User Impact

CDC progress comparisons receive positions with the intended commit-first ordering, consistent with the other position builders. The serialized checkpoint format is unchanged.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
