### PR TITLE
fix(source-mysql): support MySQL 8.4 tagged GTIDs (Debezium 3.6.2)

### DIFF
--- a/airbyte-cdk/bulk/core/extract/changelog.md
+++ b/airbyte-cdk/bulk/core/extract/changelog.md
@@ -7,6 +7,10 @@ The Extract CDK provides functionality for source connectors including schema di
 <details>
   <summary>Expand to review</summary>
 
+### 1.2.0 — 2026-09-11
+
+[#85846](https://github.com/airbytehq/airbyte/issues/85846) — Upgrade Debezium to 3.6.2.Final so that MySQL 8.4 tagged GTIDs (WL#15294) parse, and add a per-column `partialConverters(column)` hook to `RelationalColumnCustomConverter.Handler`.
+
 ### 1.1.11 — 2026-09-02
 
 [#85313](https://github.com/airbytehq/airbyte/pull/85313) — Tolerate empty STREAM-typed input state in global (CDC) mode instead of failing.

--- a/airbyte-cdk/bulk/core/extract/version.properties
+++ b/airbyte-cdk/bulk/core/extract/version.properties
@@ -1,1 +1,1 @@
-version=1.1.11
+version=1.2.0

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api platform('io.debezium:debezium-bom:3.1.2.Final')
+    api platform('io.debezium:debezium-bom:3.6.2.Final')
     api 'io.debezium:debezium-api'
     api 'io.debezium:debezium-embedded'
 
@@ -10,7 +10,9 @@ dependencies {
 
     testFixturesImplementation testFixtures(project(':airbyte-cdk:bulk:core:bulk-cdk-core-base'))
     testFixturesImplementation testFixtures(project(':airbyte-cdk:bulk:core:bulk-cdk-core-extract'))
-    testFixturesImplementation platform('org.testcontainers:testcontainers-bom:1.21.4')
+    // enforced: Debezium 3.6's BOM would otherwise pull Testcontainers 2.x
+    testFixturesImplementation enforcedPlatform('org.testcontainers:testcontainers-bom:1.21.4')
+    testImplementation enforcedPlatform('org.testcontainers:testcontainers-bom:1.21.4')
     constraints {
         testFixturesImplementation('org.testcontainers:testcontainers') {
             version {
@@ -23,7 +25,10 @@ dependencies {
     testImplementation 'io.debezium:debezium-connector-postgres'
     testImplementation 'io.debezium:debezium-connector-mongodb'
     testImplementation 'io.debezium:debezium-connector-sqlserver'
-    testFixturesImplementation 'io.debezium:debezium-testing-testcontainers' // required for testing with mongo
+    // required for testing with mongo; Debezium 3.6 pulls Testcontainers 2.x, the CDK is pinned to 1.21.4
+    testFixturesImplementation('io.debezium:debezium-testing-testcontainers') {
+        exclude group: 'org.testcontainers'
+    }
     testFixturesImplementation 'io.mockk:mockk:1.14.4'
     testImplementation 'org.testcontainers:mysql'
     testImplementation 'org.testcontainers:postgresql'

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumStateFilesAccessor.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/DebeziumStateFilesAccessor.kt
@@ -49,6 +49,9 @@ class DebeziumStateFilesAccessor : AutoCloseable {
                 WorkerConfig.KEY_CONVERTER_CLASS_CONFIG to JsonConverter::class.java.name,
                 WorkerConfig.VALUE_CONVERTER_CLASS_CONFIG to JsonConverter::class.java.name,
                 StandaloneConfig.OFFSET_STORAGE_FILE_FILENAME_CONFIG to offsetFilePath.toString(),
+                // Kafka Connect 4.x made bootstrap.servers mandatory in StandaloneConfig.
+                // The file-backed offset store never contacts a broker, so the value is unused.
+                WorkerConfig.BOOTSTRAP_SERVERS_CONFIG to "localhost:9092",
             )
         fileOffsetBackingStore.configure(StandaloneConfig(fileOffsetConfig))
     }

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/RelationalColumnCustomConverter.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/main/kotlin/io/airbyte/cdk/read/cdc/RelationalColumnCustomConverter.kt
@@ -27,6 +27,12 @@ interface RelationalColumnCustomConverter : CustomConverter<SchemaBuilder, Relat
 
         /** Partial conversion functions, applied in sequence until conversion occurs. */
         val partialConverters: List<PartialConverter>
+
+        /**
+         * Same as [partialConverters], for handlers which need per-column state. Called once per
+         * column, so the returned list may close over state scoped to that column.
+         */
+        fun partialConverters(column: RelationalColumn): List<PartialConverter> = partialConverters
     }
 
     override fun configure(props: Properties?) {}
@@ -40,7 +46,7 @@ interface RelationalColumnCustomConverter : CustomConverter<SchemaBuilder, Relat
         }
         val handler: Handler = handlers.find { it.matches(column) } ?: return
         val converter: CustomConverter.Converter =
-            ConverterFactory(javaClass).build(column, handler.partialConverters)
+            ConverterFactory(javaClass).build(column, handler.partialConverters(column))
         registration.register(handler.outputSchemaBuilder(), converter)
     }
 }

--- a/airbyte-cdk/bulk/toolkits/extract-cdc/src/testFixtures/kotlin/io/airbyte/cdk/read/cdc/AbstractCdcPartitionReaderTest.kt
+++ b/airbyte-cdk/bulk/toolkits/extract-cdc/src/testFixtures/kotlin/io/airbyte/cdk/read/cdc/AbstractCdcPartitionReaderTest.kt
@@ -298,7 +298,7 @@ abstract class AbstractCdcPartitionReaderTest<T : PartiallyOrdered<T>, C : AutoC
             val offset =
                 DebeziumOffset(
                     offsetNode
-                        .fields()
+                        .properties()
                         .asSequence()
                         .map { Jsons.readTree(it.key) to Jsons.readTree(it.value.asText()) }
                         .toMap(),

--- a/airbyte-integrations/connectors/source-mysql/gradle.properties
+++ b/airbyte-integrations/connectors/source-mysql/gradle.properties
@@ -1,3 +1,3 @@
 testExecutionConcurrency=1
 JunitMethodExecutionTimeout=5m
-cdkVersion=1.1.10
+cdkVersion=1.2.0

--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.53.4
+  dockerImageTag: 3.53.5
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceCdcTemporalConverter.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceCdcTemporalConverter.kt
@@ -23,6 +23,7 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import org.apache.kafka.connect.data.SchemaBuilder
 
 class MySqlSourceCdcTemporalConverter : RelationalColumnCustomConverter {
@@ -35,6 +36,7 @@ class MySqlSourceCdcTemporalConverter : RelationalColumnCustomConverter {
             DatetimeMicrosHandler,
             DateHandler,
             TimeHandler,
+            NullableTimestampHandler,
             TimestampHandler
         )
 
@@ -184,15 +186,42 @@ class MySqlSourceCdcTemporalConverter : RelationalColumnCustomConverter {
             )
     }
 
+    /**
+     * TIMESTAMP columns which permit NULL. A NULL here is a genuine value, so it is passed through
+     * and the schema is nullable, unlike [TimestampHandler].
+     */
+    data object NullableTimestampHandler : RelationalColumnCustomConverter.Handler {
+        override fun matches(column: RelationalColumn): Boolean =
+            column.typeName().equals("TIMESTAMP", ignoreCase = true) && column.isOptional
+
+        override fun outputSchemaBuilder(): SchemaBuilder = SchemaBuilder.string().optional()
+
+        override val partialConverters: List<PartialConverter> =
+            listOf(NullFallThrough) + TimestampHandler.valueConverters
+    }
+
+    /**
+     * NOT NULL TIMESTAMP columns. Since Debezium 3.6 the zero-date sentinel arrives as NULL rather
+     * than as 0, which would violate the required field. Such a column cannot hold a genuine NULL,
+     * so a NULL here is always a zero-date and is mapped to the Unix epoch, as before.
+     */
     data object TimestampHandler : RelationalColumnCustomConverter.Handler {
+
+        private val EPOCH_TIMESTAMP: String =
+            OffsetDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC)
+                .format(OffsetDateTimeCodec.formatter)
+
         override fun matches(column: RelationalColumn): Boolean =
             column.typeName().equals("TIMESTAMP", ignoreCase = true)
 
         override fun outputSchemaBuilder(): SchemaBuilder = SchemaBuilder.string()
 
-        override val partialConverters: List<PartialConverter> =
+        private val zeroDateToEpoch = PartialConverter {
+            if (it == null) Converted(EPOCH_TIMESTAMP) else NoConversion
+        }
+
+        internal val valueConverters: List<PartialConverter> =
             listOf(
-                NullFallThrough,
                 PartialConverter {
                     if (it is ZonedDateTime) {
                         val offsetDateTime: OffsetDateTime = it.toOffsetDateTime()
@@ -213,5 +242,32 @@ class MySqlSourceCdcTemporalConverter : RelationalColumnCustomConverter {
                     }
                 }
             )
+
+        override val partialConverters: List<PartialConverter> =
+            listOf(zeroDateToEpoch) + valueConverters
+
+        /**
+         * Debezium resolves the column's schema default by invoking the converter once, before any
+         * row, with the DDL default as input. Left alone that would make a zero-date row fall back
+         * to the DDL default instead of the epoch. Overriding that first call keeps the epoch
+         * mapping, matching the behaviour of Debezium's own ZeroDateFallbackConverter.
+         *
+         * Columns without a DDL default get no such call, so the flag is only armed when there is
+         * one, and a row value can never be mistaken for it.
+         */
+        override fun partialConverters(column: RelationalColumn): List<PartialConverter> {
+            if (!column.hasDefaultValue()) {
+                return partialConverters
+            }
+            val defaultValueResolved = AtomicBoolean()
+            val overrideDdlDefault = PartialConverter {
+                if (defaultValueResolved.compareAndSet(false, true)) {
+                    Converted(EPOCH_TIMESTAMP)
+                } else {
+                    NoConversion
+                }
+            }
+            return listOf(overrideDdlDefault) + partialConverters
+        }
     }
 }

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -539,7 +539,7 @@ class MySqlSourceDebeziumOperations(
             val offsetNode: ObjectNode = stateNode[MYSQL_CDC_OFFSET] as ObjectNode
             val offsetMap: Map<JsonNode, JsonNode> =
                 offsetNode
-                    .fields()
+                    .properties()
                     .asSequence()
                     .map { (k, v) -> Jsons.readTree(k) to Jsons.readTree(v.textValue()) }
                     .toMap()

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceTaggedGtidIntegrationTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceTaggedGtidIntegrationTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.mysql
+
+import io.airbyte.cdk.StreamIdentifier
+import io.airbyte.cdk.command.CliRunner
+import io.airbyte.cdk.discover.DiscoveredStream
+import io.airbyte.cdk.discover.EmittedField
+import io.airbyte.cdk.jdbc.IntFieldType
+import io.airbyte.cdk.jdbc.JdbcConnectionFactory
+import io.airbyte.cdk.jdbc.StringFieldType
+import io.airbyte.cdk.output.BufferingOutputConsumer
+import io.airbyte.integrations.source.mysql.MySqlContainerFactory.execAsRoot
+import io.airbyte.protocol.models.v0.AirbyteRecordMessage
+import io.airbyte.protocol.models.v0.AirbyteStateMessage
+import io.airbyte.protocol.models.v0.AirbyteStream
+import io.airbyte.protocol.models.v0.CatalogHelpers
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteCatalog
+import io.airbyte.protocol.models.v0.ConfiguredAirbyteStream
+import io.airbyte.protocol.models.v0.StreamDescriptor
+import io.airbyte.protocol.models.v0.SyncMode
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.sql.Connection
+import java.sql.ResultSet
+import java.sql.Statement
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import org.testcontainers.containers.MySQLContainer
+
+/**
+ * End-to-end CDC coverage for servers whose `gtid_executed` contains tagged GTIDs.
+ *
+ * MySQL 8.4 allows a GTID to carry a tag (WL#15294), e.g. `<uuid>:mysqlsh:1-42`. InnoDB Cluster
+ * emits these for AdminAPI operations and, once present, they stay in `gtid_executed` forever.
+ * [MySqlSourceDebeziumOperations] feeds `gtid_executed` and `gtid_purged` to Debezium's GTID set
+ * parser to decide whether a saved CDC position is still valid, so a parser that cannot read tags
+ * fails every single sync against such a server.
+ *
+ * [MySqlSourceTaggedGtidTest] pins the parser behavior itself; this test pins the behavior of an
+ * actual sync against an actual server that has emitted a tagged GTID. The tag is produced with
+ * `SET @@SESSION.GTID_NEXT = 'AUTOMATIC:<tag>'`, which makes every subsequently auto-generated GTID
+ * of that session carry the tag, without needing an InnoDB Cluster to reproduce it.
+ *
+ * See https://github.com/airbytehq/airbyte/issues/85846.
+ */
+class MySqlSourceTaggedGtidIntegrationTest {
+
+    @Test
+    @Timeout(value = 300)
+    fun testCdcSyncAgainstTaggedGtidServer() {
+        // Guard against a vacuous test: the server must really be in the broken-before state.
+        assertTrue(
+            gtidExecuted().contains(":$GTID_TAG:"),
+            "expected a tagged GTID in gtid_executed, got '${gtidExecuted()}'",
+        )
+
+        val run1: BufferingOutputConsumer =
+            CliRunner.source("read", config(), configuredCatalog).run()
+        assertEquals(
+            emptyList<String>(),
+            run1.traces().filter { it.error != null }.map { it.error.internalMessage },
+        )
+        assertEquals(listOf(1, 2), run1.records().map { it.k() }.sorted())
+        val state1: AirbyteStateMessage = run1.states().last()
+
+        // Keep emitting tagged GTIDs while the connector is between syncs: the incremental read
+        // has to both resume from the tagged position and parse the ones added since.
+        dbContainer.execAsRoot(
+            "SET @@SESSION.GTID_NEXT = 'AUTOMATIC:$GTID_TAG';" +
+                "INSERT INTO test.tbl (k, v) VALUES (3, 'baz');" +
+                "SET @@SESSION.GTID_NEXT = 'AUTOMATIC';",
+        )
+
+        val run2InputState: List<AirbyteStateMessage> = listOf(state1)
+        val run2: BufferingOutputConsumer =
+            CliRunner.source("read", config(), configuredCatalog, run2InputState).run()
+        assertEquals(
+            emptyList<String>(),
+            run2.traces().filter { it.error != null }.map { it.error.internalMessage },
+        )
+        assertEquals(listOf(3), run2.records().map { it.k() })
+        assertTrue(gtidExecuted().contains(":$GTID_TAG:"))
+    }
+
+    companion object {
+        val log = KotlinLogging.logger {}
+        lateinit var dbContainer: MySQLContainer<*>
+
+        const val GTID_TAG = "airbyte"
+
+        fun config(): MySqlSourceConfigurationSpecification =
+            MySqlContainerFactory.config(dbContainer).apply { setIncrementalValue(Cdc()) }
+
+        val connectionFactory: JdbcConnectionFactory by lazy {
+            JdbcConnectionFactory(MySqlSourceConfigurationFactory().make(config()))
+        }
+
+        val configuredCatalog: ConfiguredAirbyteCatalog by lazy {
+            val desc = StreamDescriptor().withName("tbl").withNamespace("test")
+            val discoveredStream =
+                DiscoveredStream(
+                    id = StreamIdentifier.Companion.from(desc),
+                    columns =
+                        listOf(EmittedField("k", IntFieldType), EmittedField("v", StringFieldType)),
+                    primaryKeyColumnIDs = listOf(listOf("k")),
+                )
+            val stream: AirbyteStream =
+                MySqlSourceOperations()
+                    .create(
+                        MySqlSourceConfigurationFactory().make(config()),
+                        discoveredStream,
+                    )
+            val configuredStream: ConfiguredAirbyteStream =
+                CatalogHelpers.toDefaultConfiguredStream(stream)
+                    .withSyncMode(SyncMode.INCREMENTAL)
+                    .withPrimaryKey(discoveredStream.primaryKeyColumnIDs)
+                    .withCursorField(listOf(MySqlSourceCdcMetaFields.CDC_CURSOR.id))
+            ConfiguredAirbyteCatalog().withStreams(listOf(configuredStream))
+        }
+
+        @JvmStatic
+        @BeforeAll
+        @Timeout(value = 300)
+        fun startAndProvisionTestContainer() {
+            dbContainer =
+                MySqlContainerFactory.exclusive(
+                    imageName = "mysql:9.2.0",
+                    MySqlContainerFactory.WithNetwork,
+                    MySqlContainerFactory.WithCdc,
+                )
+            connectionFactory.get().use { connection: Connection ->
+                connection.isReadOnly = false
+                connection.createStatement().use { stmt: Statement ->
+                    stmt.execute("CREATE TABLE test.tbl(k INT PRIMARY KEY, v VARCHAR(80))")
+                }
+                connection.createStatement().use { stmt: Statement ->
+                    stmt.execute("INSERT INTO test.tbl (k, v) VALUES (1, 'foo'), (2, 'bar')")
+                }
+            }
+            // The untagged transactions above plus this tagged one give the mixed
+            // '<uuid>:1-N:<tag>:1-M' shape that an InnoDB Cluster member reports.
+            dbContainer.execAsRoot(
+                "SET @@SESSION.GTID_NEXT = 'AUTOMATIC:$GTID_TAG';" +
+                    "CREATE TABLE test.tagged_marker(k INT PRIMARY KEY);" +
+                    "SET @@SESSION.GTID_NEXT = 'AUTOMATIC';",
+            )
+            log.info { "gtid_executed after provisioning: ${gtidExecuted()}" }
+        }
+
+        fun gtidExecuted(): String =
+            connectionFactory.get().use { connection: Connection ->
+                connection.createStatement().use { stmt: Statement ->
+                    stmt.executeQuery("SELECT @@GLOBAL.GTID_EXECUTED").use { rs: ResultSet ->
+                        rs.next()
+                        // MySQL wraps long GTID sets, the tag delimiters do not survive otherwise.
+                        rs.getString(1).replace("\n", "")
+                    }
+                }
+            }
+
+        fun AirbyteRecordMessage.k(): Int = data["k"].asInt()
+    }
+}

--- a/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceTaggedGtidTest.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/test/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceTaggedGtidTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Airbyte, Inc., all rights reserved.
+ */
+
+package io.airbyte.integrations.source.mysql
+
+import io.debezium.connector.mysql.gtid.MySqlGtidSet
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * MySQL 8.4 allows GTIDs to carry a tag (WL#15294), e.g. `<uuid>:mysqlsh:1-42`. InnoDB Cluster
+ * emits these for AdminAPI operations, and once present they stay in `gtid_executed` forever.
+ *
+ * [MySqlSourceDebeziumOperations] parses `gtid_executed` and `gtid_purged` into [MySqlGtidSet] to
+ * decide whether the saved CDC position is still valid, so a parser that cannot read tags fails
+ * every sync against such a server.
+ *
+ * See https://github.com/airbytehq/airbyte/issues/85846.
+ */
+class MySqlSourceTaggedGtidTest {
+
+    companion object {
+        const val UUID = "3e11fa47-71ca-11e1-9e33-c80aa9429562"
+    }
+
+    @Test
+    fun testTaggedGtidSetIsParsed() {
+        val gtidSet = MySqlGtidSet("$UUID:mysqlsh:1-42")
+        assertEquals(1, gtidSet.uuidSets.size)
+        assertEquals("$UUID:mysqlsh:1-42", gtidSet.toString())
+    }
+
+    /**
+     * The tagged and untagged transactions of one server are distinct sets. Collapsing them onto
+     * the bare UUID silently drops one of the two, which would let the connector skip transactions
+     * it never read.
+     */
+    @Test
+    fun testTaggedAndUntaggedSetsOfSameServerAreDistinct() {
+        val gtidSet = MySqlGtidSet("$UUID:1-5:mysqlsh:1-3")
+        assertEquals(2, gtidSet.uuidSets.size)
+        assertEquals("$UUID:1-5:mysqlsh:1-3", gtidSet.toString())
+    }
+
+    @Test
+    fun testContainmentIsTagAware() {
+        val available = MySqlGtidSet("$UUID:1-5:mysqlsh:1-3")
+        assertTrue(MySqlGtidSet("$UUID:1-5").isContainedWithin(available))
+        assertTrue(MySqlGtidSet("$UUID:mysqlsh:1-3").isContainedWithin(available))
+        // the untagged set does not vouch for the tagged transactions, nor the other way around
+        assertFalse(MySqlGtidSet("$UUID:mysqlsh:1-3").isContainedWithin(MySqlGtidSet("$UUID:1-5")))
+        assertFalse(MySqlGtidSet("$UUID:1-5").isContainedWithin(MySqlGtidSet("$UUID:mysqlsh:1-5")))
+    }
+
+    @Test
+    fun testSubtractKeepsTagsApart() {
+        val available = MySqlGtidSet("$UUID:1-5:mysqlsh:1-3")
+        assertEquals("$UUID:mysqlsh:1-3", available.subtract(MySqlGtidSet("$UUID:1-5")).toString())
+        assertEquals("$UUID:1-5", available.subtract(MySqlGtidSet("$UUID:mysqlsh:1-3")).toString())
+    }
+
+    @Test
+    fun testUntaggedParsingIsUnchanged() {
+        assertEquals("$UUID:1-199", MySqlGtidSet("$UUID:1-191:192-199").toString())
+    }
+}

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -230,6 +230,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                          |
 |:------------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.53.5      | 2026-09-12 | [85855](https://github.com/airbytehq/airbyte/pull/85855)   | Replace the deprecated `JsonNode.fields()` with `properties()`. No behavior change.                                                              |
 | 3.53.4      | 2026-08-27 | [81413](https://github.com/airbytehq/airbyte/pull/81413)   | Retry CDC syncs that fail with an EOF error while reading the MySQL binlog instead of failing as a config error.                                 |
 | 3.53.3      | 2026-08-11 | [84207](https://github.com/airbytehq/airbyte/pull/84207)   | Promote to Bulk CDK 1.1.10: fix CDC meta-field decoration of full refresh streams with no source-defined primary key in speed mode.              |
 | 3.53.2      | 2026-08-06 | [83239](https://github.com/airbytehq/airbyte/pull/83239)   | Fix error 1267 (illegal mix of collations) when partitioning text primary keys with utf8mb3 or other legacy charset columns.                     |

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -230,7 +230,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                          |
 |:------------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
-| 3.53.5      | 2026-09-12 | [85855](https://github.com/airbytehq/airbyte/pull/85855)   | Replace the deprecated `JsonNode.fields()` with `properties()`. No behavior change.                                                              |
+| 3.53.5      | 2026-09-12 | [85855](https://github.com/airbytehq/airbyte/pull/85855)   | Promote to Bulk CDK 1.2.0: support MySQL 8.4 tagged GTIDs, which previously failed every CDC sync against servers using them (e.g. InnoDB Cluster). |
 | 3.53.4      | 2026-08-27 | [81413](https://github.com/airbytehq/airbyte/pull/81413)   | Retry CDC syncs that fail with an EOF error while reading the MySQL binlog instead of failing as a config error.                                 |
 | 3.53.3      | 2026-08-11 | [84207](https://github.com/airbytehq/airbyte/pull/84207)   | Promote to Bulk CDK 1.1.10: fix CDC meta-field decoration of full refresh streams with no source-defined primary key in speed mode.              |
 | 3.53.2      | 2026-08-06 | [83239](https://github.com/airbytehq/airbyte/pull/83239)   | Fix error 1267 (illegal mix of collations) when partitioning text primary keys with utf8mb3 or other legacy charset columns.                     |


### PR DESCRIPTION
## What

MySQL 8.4 allows a GTID to carry a tag (WL#15294), so `gtid_executed` can read
`<uuid>:1-42:mysqlsh:1-7` instead of `<uuid>:1-42`. InnoDB Cluster emits tagged GTIDs for AdminAPI
operations, and once one is present it stays in `gtid_executed` for the life of the server.

The bulk CDK pins Debezium 3.1.2, whose `MySqlGtidSet` predates tagged GTIDs. It keys intervals by
UUID alone and cannot parse the tagged grammar, so every CDC sync against such a server fails. The
tag-aware parser landed in Debezium 3.6.

Fixes #85846

## How

**Bulk CDK (extract 1.1.10 → 1.2.0)**

- `debezium-bom` 3.1.2 → **3.6.2.Final**, which brings a tag-aware `MySqlGtidSet` and
  `mysql-binlog-connector-java` 0.41.2.
- Debezium 3.6's BOM would drag in Testcontainers 2.x. Testcontainers is held at 1.21.4 with an
  `enforcedPlatform` plus a strict constraint, and `debezium-testing-testcontainers` excludes the
  `org.testcontainers` group.
- Debezium 3.6 also bumps Jackson transitively (2.17.2 → 2.21.2), which deprecates
  `JsonNode.fields()`. Under Kotlin `-Werror` that is a build failure, so the affected call sites
  move to `JsonNode.properties()` (available since Jackson 2.15).
- New `RelationalColumnCustomConverter.Handler.partialConverters(column)` overload, for handlers
  that need per-column state. It is a default method delegating to the existing
  `partialConverters` property, so every current handler is unaffected.

**`source-mysql` (3.53.4 → 3.53.5)**

- Adopts CDK 1.2.0, which is what actually fixes tagged GTIDs.
- Debezium 3.6 changed how a zero-date `TIMESTAMP` reaches a custom converter: it now arrives as
  `NULL` rather than `0`, which fails a required field. `MySqlSourceCdcTemporalConverter` splits the
  `TIMESTAMP` handler in two so emitted values are unchanged — nullable columns pass a genuine
  `NULL` through; `NOT NULL` columns cannot hold one, so a `NULL` there is always a zero-date and
  still maps to the Unix epoch.
- For a `NOT NULL` column with a DDL default, Debezium resolves the schema default by invoking the
  converter once before any row. That first call is overridden via the new per-column hook, matching
  the behavior of Debezium's own `ZeroDateFallbackConverter`.
- Two regression tests: a unit test pinning tagged-GTID parsing/containment/subtraction, and an
  integration test that provisions a container with `SET @@SESSION.GTID_NEXT = 'AUTOMATIC:<tag>'`
  and runs an initial plus an incremental CDC read against it.

## Review guide

1. `airbyte-cdk/bulk/toolkits/extract-cdc/build.gradle` — the BOM bump and Testcontainers pinning.
2. `.../cdk/read/cdc/RelationalColumnCustomConverter.kt` — the new per-column hook.
3. `.../source/mysql/MySqlSourceCdcTemporalConverter.kt` — the zero-date `TIMESTAMP` handling.
4. `.../source/mysql/MySqlSourceTaggedGtidIntegrationTest.kt` — end-to-end coverage.
5. `airbyte-cdk/bulk/core/extract/version.properties` and `changelog.md`.

## On the red checks

This PR touches both the bulk CDK and `source-mysql`, which is normally split into two PRs. Here the
two halves are mutually dependent and neither can be green on its own, so they are submitted
together. Several checks are red as a direct consequence, and I would rather state that than paper
over it:

1. **`Enforce PR structure`** — fails by definition on a PR that touches both trees.
2. **`Test source-mysql Connector [No Creds]`** and **`Lint source-mysql Connector`** — both build
   the connector against the *declared* `cdkVersion`, and
   `io.airbyte.bulk-cdk:bulk-cdk-core-extract:1.2.0` does not exist yet (it publishes from `master`
   on merge of this PR):

   ```
   > Could not find io.airbyte.bulk-cdk:bulk-cdk-core-extract:1.2.0.
     Searched in the following locations:
       - https://airbyte.mycloudrepo.io/public/repositories/airbyte-public-jars/...
       - https://repo.maven.apache.org/maven2/...
   ```

   Declaring `1.1.10` instead is not an option: the converter fix overrides
   `partialConverters(column)`, which 1.1.10 does not have. Both checks go green once the CDK
   publishes.
3. **`source-mysql Progressive Rollout Gate`** and its summary — these need repository secrets that
   are not available to a fork PR.
4. **`CDK Check`** — unrelated flake, and I do not have permission to re-run it. It fails in
   `:airbyte-cdk:java:airbyte-cdk:airbyte-cdk-core:test`, the *legacy* Java CDK, on
   `AirbyteLogMessageTemplateTest > testAirbyteLogMessageFormat()`. That test asserts on captured
   log output and captured a line emitted by a different test running concurrently in the same
   pool:

   ```
   expected: <true> but was: <false>
   INFO ForkJoinPool-1-worker-2 ... Junit starting execution of @BeforeEach method
   TestDefaultJdbcDatabase.setup with timeout of 1 minute
   ```

   This PR changes nothing under `airbyte-cdk/java/**` and no shared build configuration, and
   nothing in that tree references the bulk CDK, so it cannot be an input to that module. A re-run
   from anyone with the rights would confirm it.

The check that actually matters for this change, **`Test source-mysql`** (the CDK compatibility
test, which runs `upgradeCdk --cdkVersion=local` and so exercises the real pairing), is green — as
are `Test source-postgres`, `Test source-mssql`, `Test source-snowflake` and `Test source-datagen`
against Debezium 3.6.2, plus `Connectors CDK Version Check`, `Bulk CDK version check`,
`Format Check` and `Analyze Java/Kotlin`.

Happy to restructure into a sequence of individually-green PRs if maintainers prefer — CDK hook
only, then connector adoption, then the Debezium bump, then the tagged-GTID test. It is four review
cycles and two CDK releases instead of one, which is why it is not what is proposed here.

## User Impact

Fixes CDC syncs against MySQL 8.4 / InnoDB Cluster servers that have emitted tagged GTIDs, which
currently fail every sync.

One behavior change is worth calling out for other Debezium-based connectors: Debezium 3.6 delivers
zero-value `TIMESTAMP` columns as `NULL` rather than raising. `source-mysql` handles this here; other
connectors may want to check their temporal converters. `source-postgres`, `source-mssql`,
`source-snowflake` and `source-datagen` all pass against 3.6.2 in this PR's compatibility run.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

## Verification

Run locally against this branch:

- `:airbyte-cdk:bulk:toolkits:bulk-cdk-toolkit-extract-cdc:test --rerun-tasks` — 17 tests,
  0 failures, 1 skipped (`CdcPartitionReaderMongoTest`).
- `:airbyte-integrations:connectors:source-mysql:test :…:integrationTestJava -PcdkVersion=local
  --rerun-tasks` — **244 tests, 0 failures, 0 errors, 0 skipped**, including
  `MySqlSourceDatatypeIntegrationTest` (which fails without the converter fix) and both new
  tagged-GTID tests. This is the configuration `Test source-mysql` builds.
- `mvn -f spotless-maven-pom.xml spotless:apply` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
