### PR TITLE
fix(source-mysql): replace deprecated JsonNode.fields() with properties()

### DIFF
--- a/airbyte-integrations/connectors/source-mysql/metadata.yaml
+++ b/airbyte-integrations/connectors/source-mysql/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: 435bb9a5-7887-4809-aa58-28c27df0d7ad
-  dockerImageTag: 3.53.4
+  dockerImageTag: 3.53.5
   dockerRepository: airbyte/source-mysql
   documentationUrl: https://docs.airbyte.com/integrations/sources/mysql
   githubIssueLabel: source-mysql

--- a/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
+++ b/airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt
@@ -539,7 +539,7 @@ class MySqlSourceDebeziumOperations(
             val offsetNode: ObjectNode = stateNode[MYSQL_CDC_OFFSET] as ObjectNode
             val offsetMap: Map<JsonNode, JsonNode> =
                 offsetNode
-                    .fields()
+                    .properties()
                     .asSequence()
                     .map { (k, v) -> Jsons.readTree(k) to Jsons.readTree(v.textValue()) }
                     .toMap()

--- a/docs/integrations/sources/mysql.md
+++ b/docs/integrations/sources/mysql.md
@@ -230,6 +230,7 @@ If you use Airbyte Cloud and your organization restricts access to specific IPs,
 
 | Version     | Date       | Pull Request                                               | Subject                                                                                                                                          |
 |:------------|:-----------|:-----------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| 3.53.5      | 2026-09-12 | [85856](https://github.com/airbytehq/airbyte/pull/85856)   | Replace the deprecated `JsonNode.fields()` with `properties()`. No behavior change.                                                              |
 | 3.53.4      | 2026-08-27 | [81413](https://github.com/airbytehq/airbyte/pull/81413)   | Retry CDC syncs that fail with an EOF error while reading the MySQL binlog instead of failing as a config error.                                 |
 | 3.53.3      | 2026-08-11 | [84207](https://github.com/airbytehq/airbyte/pull/84207)   | Promote to Bulk CDK 1.1.10: fix CDC meta-field decoration of full refresh streams with no source-defined primary key in speed mode.              |
 | 3.53.2      | 2026-08-06 | [83239](https://github.com/airbytehq/airbyte/pull/83239)   | Fix error 1267 (illegal mix of collations) when partitioning text primary keys with utf8mb3 or other legacy charset columns.                     |


### PR DESCRIPTION
## What

`MySqlSourceDebeziumOperations` calls `JsonNode.fields()`, which Jackson has deprecated in favor of
`JsonNode.properties()`. Kotlin is configured with `-Werror` for connectors, so this becomes a hard
compile failure the moment source-mysql resolves a Jackson version new enough to carry the
deprecation.

That is not hypothetical. It is the only thing failing CI on #85855, which upgrades the bulk CDK to
Debezium 3.6.2.Final and transitively moves Jackson 2.17.2 → 2.21.2:

```
e: warnings found and -Werror specified
w: .../MySqlSourceDebeziumOperations.kt:542:22 'fields()' ... is deprecated. Deprecated in Java
> Task :airbyte-integrations:connectors:source-mysql:compileKotlin FAILED
```

Landing this small change first means #85855 does not break `source-mysql` on master, and
`.github/workflows/jvm-connector-pr-structure.yml` keeps CDK and connector changes in separate PRs
as intended.

## How

One call site, `fields()` → `properties()`. `properties()` has been available since Jackson 2.15 and
source-mysql currently builds against bulk CDK 1.1.10 / Jackson 2.17.2, so this compiles both before
and after the CDK upgrade.

No behavior change: the two methods expose the same entries, as an `Iterator` and a `Set`
respectively, and both feed the existing `.asSequence()` identically.

## Review guide

1. `airbyte-integrations/connectors/source-mysql/src/main/kotlin/io/airbyte/integrations/source/mysql/MySqlSourceDebeziumOperations.kt`

## User Impact

None. Internal refactor, no functional change.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚

## Verification

`:airbyte-integrations:connectors:source-mysql:compileKotlin --rerun-tasks` run locally against
current master with this change: `BUILD SUCCESSFUL`, no warnings from this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
