### PR TITLE
docs(cloud): update plan and billing docs

### DIFF
--- a/docs/platform/access-management/sso-providers/azure-entra-id.md
+++ b/docs/platform/access-management/sso-providers/azure-entra-id.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Entra ID
-products: cloud
+products: cloud-plus
 ---
 
 # Set up single sign on using Entra ID

--- a/docs/platform/access-management/sso-providers/okta.md
+++ b/docs/platform/access-management/sso-providers/okta.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Okta
-products: cloud
+products: cloud-plus
 ---
 
 # Set up single sign on using Okta

--- a/docs/platform/access-management/sso.md
+++ b/docs/platform/access-management/sso.md
@@ -1,5 +1,5 @@
 ---
-products: cloud
+products: cloud-plus
 ---
 
 # Single sign on (SSO)
@@ -11,6 +11,10 @@ import CaptureHarFile from '../_partials/_capture-har-file.md';
 Use Open ID Connect (OIDC) to log into Airbyte using an Identity Provider (IdP) like Okta or Entra ID/Active Directory.
 
 SCIM provisioning is an add-on to SSO. After you set up SSO, see [SCIM provisioning](scim) to configure user and group provisioning.
+
+:::note
+SSO isn't available on the Cloud Standard plan. If your Standard organization already uses SSO, you keep it as long as you remain a paying customer. To compare plans, see [Airbyte's pricing page](https://airbyte.com/pricing).
+:::
 
 ## Set up single sign on
 

--- a/docs/platform/cloud/managing-airbyte-cloud/manage-credits.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-credits.md
@@ -8,7 +8,7 @@ In order to manage your payment and billing information, you need the **Organiza
 
 ## What are credits?
 
-Airbyte credits are used to pay for Airbyte resources when you run a sync. Each plan includes a number of credits per month, and you can buy additional credits. For plan and credit pricing, see [Airbyte's pricing page](https://airbyte.com/pricing).
+Airbyte credits are used to pay for Airbyte resources when you run a sync on the Standard and Plus plans. Each plan includes a number of credits per month, and you can buy additional credits. Pro and Enterprise Flex are capacity-based plans that use [data workers](manage-data-workers) instead. For plan and credit pricing, see [Airbyte's pricing page](https://airbyte.com/pricing).
 
 Airbyte uses credits to unify usage across multiple types of sources. You can refer to the below table to estimate how many credits a sync consumes for each source type.
 
@@ -37,9 +37,11 @@ If you pass $10,000 (USD) in credit usage during a billing period, Airbyte autom
 
 The Plan page is where you select and manage your Airbyte Cloud plan. To open it, click **Organization settings** in the navigation bar, then click **Plan**.
 
-- **Standard** and **Plus** are self-serve. You can subscribe, upgrade, or downgrade between them from the Plan page. On Plus, you also choose the number of credits included in your plan each month.
+- **Standard** and **Plus** are self-serve. You can subscribe to either plan, or upgrade from Standard to Plus, from the Plan page. On Plus, you also choose the number of credits included in your plan each month.
 
-- **Pro** and **Enterprise Flex** are contracted, capacity-based plans. To move to one of these plans, or to change plans while you're on Plus or Enterprise Flex, [contact Sales](https://airbyte.com/company/talk-to-sales).
+- **Pro** and **Enterprise Flex** are contracted, capacity-based plans. To move to one of these plans, [contact Sales](https://airbyte.com/company/talk-to-sales).
+
+- You can't downgrade from Plus or Enterprise Flex to another plan on your own. [Contact Sales](https://airbyte.com/company/talk-to-sales) to downgrade.
 
 For what each plan includes and what it costs, see [Airbyte's pricing page](https://airbyte.com/pricing).
 
@@ -75,7 +77,7 @@ Airbyte automatically charges the credit card on file at the end of each month's
 
 ### Review your subscription
 
-The Subscription section shows the plan you're enrolled in. To change plans or the number of credits in your plan, use the [Plan page](#choose-or-change-your-plan).
+The Subscription section shows the plan you're enrolled in. To upgrade to Plus or change the number of credits in your Plus plan, use the [Plan page](#choose-or-change-your-plan).
 
 Reach out to [Sales](https://airbyte.com/company/talk-to-sales) to inquire about Pro, Enterprise Flex, new features, or custom discounts.
 

--- a/docs/platform/cloud/managing-airbyte-cloud/manage-credits.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-credits.md
@@ -35,15 +35,13 @@ If you pass $10,000 (USD) in credit usage during a billing period, Airbyte autom
 
 ## Choose or change your plan
 
-The Plan page is where you select and manage your Airbyte Cloud plan. To open it, click **Organization settings** in the navigation bar, then click **Plan**.
+Manage your plan from the Plan page. To open it, click **Organization settings** in the navigation bar, then click **Plan**.
 
-- **Standard** and **Plus** are self-serve. You can subscribe to either plan, or upgrade from Standard to Plus, from the Plan page. On Plus, you also choose the number of credits included in your plan each month.
+- **Standard** and **Plus** are self-serve. You can subscribe to either plan, switch between them, and choose how many credits your Plus plan includes each month.
 
-- **Pro** and **Enterprise Flex** are contracted, capacity-based plans. To move to one of these plans, [contact Sales](https://airbyte.com/company/talk-to-sales).
+- **Pro** and **Enterprise Flex** are contracted, capacity-based plans. [Contact Sales](https://airbyte.com/company/talk-to-sales) to move to one of these plans or to change plans once you're on one.
 
-- You can't downgrade from Plus or Enterprise Flex to another plan on your own. [Contact Sales](https://airbyte.com/company/talk-to-sales) to downgrade.
-
-For what each plan includes and what it costs, see [Airbyte's pricing page](https://airbyte.com/pricing).
+To compare plans and pricing, see [Airbyte's pricing page](https://airbyte.com/pricing).
 
 ## Start a trial
 
@@ -77,7 +75,7 @@ Airbyte automatically charges the credit card on file at the end of each month's
 
 ### Review your subscription
 
-The Subscription section shows the plan you're enrolled in. To upgrade to Plus or change the number of credits in your Plus plan, use the [Plan page](#choose-or-change-your-plan).
+The Subscription section shows the plan you're enrolled in. To change plans or the number of credits in your Plus plan, use the [Plan page](#choose-or-change-your-plan).
 
 Reach out to [Sales](https://airbyte.com/company/talk-to-sales) to inquire about Pro, Enterprise Flex, new features, or custom discounts.
 

--- a/docs/platform/cloud/managing-airbyte-cloud/manage-credits.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/manage-credits.md
@@ -8,16 +8,16 @@ In order to manage your payment and billing information, you need the **Organiza
 
 ## What are credits?
 
-Airbyte [credits](https://airbyte.com/pricing) are used to pay for Airbyte resources when you run a sync. Airbyte Cloud plans start at $10 per month, which includes 4 credits. Additional credits are available at $2.50 each.
+Airbyte credits are used to pay for Airbyte resources when you run a sync. Each plan includes a number of credits per month, and you can buy additional credits. For plan and credit pricing, see [Airbyte's pricing page](https://airbyte.com/pricing).
 
-Airbyte uses credits to unify pricing across multiple types of sources. You can refer to the below table to understand how pricing differs across each source.
+Airbyte uses credits to unify usage across multiple types of sources. You can refer to the below table to estimate how many credits a sync consumes for each source type.
 
-| Source Type    | Billing Type | Price                | Credit Equivalent |
-| -------------- | ------------ | -------------------- | ----------------- |
-| APIs           | Rows         | $15 per million rows | 6 credits         |
-| Databases      | GB           | $10 per GB           | 4 credits         |
-| Files          | GB           | $10 per GB           | 4 credits         |
-| Custom sources | Rows         | $15 per million rows | 6 credits         |
+| Source Type    | Billing Type | Usage        | Credits   |
+| -------------- | ------------ | ------------ | --------- |
+| APIs           | Rows         | Million rows | 6 credits |
+| Databases      | GB           | 1 GB         | 4 credits |
+| Files          | GB           | 1 GB         | 4 credits |
+| Custom sources | Rows         | Million rows | 6 credits |
 
 For APIs and custom sources, most syncs happen incrementally, so the row amount is typically those rows added, edited, or deleted. For Full Refresh syncs, every row synced is charged.
 
@@ -33,9 +33,15 @@ All pricing is in USD.
 
 If you pass $10,000 (USD) in credit usage during a billing period, Airbyte automatically charges your saved payment method and issues an invoice.
 
-## Purchase credits
+## Choose or change your plan
 
-If you want to pre-purchase credits, [contact Sales](https://airbyte.com/company/talk-to-sales).
+The Plan page is where you select and manage your Airbyte Cloud plan. To open it, click **Organization settings** in the navigation bar, then click **Plan**.
+
+- **Standard** and **Plus** are self-serve. You can subscribe, upgrade, or downgrade between them from the Plan page. On Plus, you also choose the number of credits included in your plan each month.
+
+- **Pro** and **Enterprise Flex** are contracted, capacity-based plans. To move to one of these plans, or to change plans while you're on Plus or Enterprise Flex, [contact Sales](https://airbyte.com/company/talk-to-sales).
+
+For what each plan includes and what it costs, see [Airbyte's pricing page](https://airbyte.com/pricing).
 
 ## Start a trial
 
@@ -69,9 +75,7 @@ Airbyte automatically charges the credit card on file at the end of each month's
 
 ### Review your subscription
 
-The Subscription section shows the subscription plan you have enrolled in.
-
-If you're on Standard and eligible for self-serve Plus, you can upgrade from the Billing page. Plus includes everything in Standard and adds [15-minute sync schedules](/platform/using-airbyte/core-concepts/sync-schedules) and [mappings](/platform/using-airbyte/mappings). Airbyte applies Plus after checkout is complete.
+The Subscription section shows the plan you're enrolled in. To change plans or the number of credits in your plan, use the [Plan page](#choose-or-change-your-plan).
 
 Reach out to [Sales](https://airbyte.com/company/talk-to-sales) to inquire about Pro, Enterprise Flex, new features, or custom discounts.
 

--- a/docs/platform/cloud/managing-airbyte-cloud/understand-airbyte-cloud-limits.md
+++ b/docs/platform/cloud/managing-airbyte-cloud/understand-airbyte-cloud-limits.md
@@ -8,17 +8,23 @@ Understanding the following limitations will help you more effectively manage Ai
 
 ## Standard plan limitations
 
-These limitations only apply to those using the Standard plan. If you upgrade to Plus, Pro, or Enterprise Flex, Airbyte removes these limitations.
+These limitations only apply to those using the Standard plan. Upgrading to a higher plan raises or removes them. See [Airbyte's pricing page](https://airbyte.com/pricing) to compare plans.
 
-- Max number of workspaces per user: 1. If you were a Cloud Standard customer before September 24, 2025, Airbyte has grandfathered you into its historical 3-workspace limit.
+- Max number of workspaces per organization: 1. If you were a Cloud Standard customer before September 24, 2025, Airbyte has grandfathered you into its historical 3-workspace limit.
 
 - Scheduled or cron syncs can run at most every 60 minutes.
+
+- Single sign-on (SSO) isn't available. If your Standard organization already uses SSO, you keep it as long as you remain a paying customer.
 
 ## Plus plan limitations
 
 These limitations only apply to those using the Plus plan. If you upgrade to Pro or Enterprise Flex, Airbyte removes these limitations.
 
+- Max number of workspaces per organization: 2.
+
 - Scheduled or cron syncs can run at most every 15 minutes.
+
+- SSO is available, but SCIM provisioning and role-based access control aren't.
 
 ## Cloud limitations for all plans
 

--- a/docs/platform/organizations-workspaces/readme.md
+++ b/docs/platform/organizations-workspaces/readme.md
@@ -8,6 +8,6 @@ import DocCardList from '@theme/DocCardList';
 
 Organizations and workspaces are the highest levels of structure in Airbyte. They're the primary ways you segregate data and connections, manage access, and control billing.
 
-If you use Core, you only have one organization and one workspace, so these concepts aren't relevant to you. If you use Cloud Standard, each organization is limited to one workspace. You can upgrade to Pro or Enterprise Flex to access multiple workspaces per organization.
+If you use Core, you only have one organization and one workspace, so these concepts aren't relevant to you. If you use Cloud Standard, each organization is limited to one workspace. Plus includes two workspaces, and Pro and Enterprise Flex include more. See [Airbyte's pricing page](https://airbyte.com/pricing) to compare plans.
 
 <DocCardList />

--- a/docs/platform/organizations-workspaces/workspaces/readme.md
+++ b/docs/platform/organizations-workspaces/workspaces/readme.md
@@ -24,6 +24,6 @@ You can use workspaces for the following purposes.
 
 - Set up notifications.
 
-If you use Core, you only have one workspace. If you use Cloud Standard, each organization is limited to one workspace. You can upgrade to Pro or Enterprise Flex to access multiple workspaces per organization.
+If you use Core, you only have one workspace. If you use Cloud Standard, each organization is limited to one workspace. Plus includes two workspaces, and Pro and Enterprise Flex include more. See [Airbyte's pricing page](https://airbyte.com/pricing) to compare plans.
 
 <DocCardList />

--- a/docs/platform/readme.md
+++ b/docs/platform/readme.md
@@ -75,7 +75,7 @@ Airbyte's data replication platform is available as a self-managed, hybrid, or f
 
 <CardWithIcon title="Standard" description="A cloud solution that provides a fully managed experience for data replication. Focus on moving data while Airbyte manages the infrastructure. Free 30-day trial." ctaText="Sign up" ctaLink="https://cloud.airbyte.com/signup" icon="fa-cloud" />
 
-<CardWithIcon title="Plus" description="A self-serve upgrade with everything in Standard, plus 15-minute sync schedules, mappings, and higher priority support." ctaText="Sign up" ctaLink="https://cloud.airbyte.com/signup" icon="fa-cloud" />
+<CardWithIcon title="Plus" description="A self-serve upgrade with everything in Standard, plus more frequent syncs, more workspaces, single sign on, and premium support. Choose the number of credits that fits your usage." ctaText="Sign up" ctaLink="https://cloud.airbyte.com/signup" icon="fa-cloud" />
 
 <CardWithIcon title="Pro" description="A cloud solution for organizations looking to scale efficiently. Role based access control, single sign on, and more ensure Pro is a robust solution that can grow with your team." ctaText="Talk to Sales" ctaLink="https://airbyte.com/company/talk-to-sales" icon="fa-lock" />
 

--- a/docs/release_notes/cloud/readme.md
+++ b/docs/release_notes/cloud/readme.md
@@ -4,17 +4,17 @@ Airbyte Cloud is updated continuously. You always have the latest features and f
 
 ## September 14, 2026
 
-Platform
+**Important**: Updated pricing model
 
 - **Airbyte Cloud has a new pricing model** for self-serve plans (Standard and Plus). Pro and Flex are not affected. For many of you, **the price of the Plus plan is significantly cheaper** than the price of the Standard plan. We strongly recommend visiting [Airbyte's pricing page](https://airbyte.com/pricing) to determine the optimal plan for you. New Plus plans are available immediately. The Standard plan switches on September 21. Here's what's changing:
     - **Standard**: the base price for Standard increases from $10 per month to $20 per month. The number of free credits each month also increases from 4 to 5. The price for additional credits increases from $2.50 to $5.00. Single sign on (SSO) is no longer available on Standard, but if you already use SSO, you may continue doing so as long as you keep your plan.
     - **Plus**: Multiple new pricing tiers are available. All Plus plans include a much larger allocation of credits, less expensive overage credits, 15-minute sync frequency, two workspaces, mappings (renames only), single sign-on, and premium support. Existing Plus subscribers are being moved from 50 to 100 credits and your plan cost has dropped $50. The following Plus tiers are available:
-        - 40 credits - $189 (equivalent to $4.75/cr) + $5 per credit for overages
-        - 100 credits - $449 (equivalent to $4.5/cr) + $5 per credit for overages
-        - 250 credits - $999 (equivalent to $4/cr) + $4.5 per credit for overages
-        - 500 credits - $1,799 (equivalent to $3.6/cr) + $4.15 per credit for overages
-        - 1,000 credits - $3,199 (equivalent to $3.2/cr) + $3.75 per credit for overages
-        - 2,000 credits - $4,999 (equivalent to $2.5/cr) + $2.5 per credit for overages
+        - 40 credits: $189 (equivalent to $4.75/cr) + $5/cr for overages
+        - 100 credits: $449 (equivalent to $4.5/cr) + $5/cr for overages
+        - 250 credits: $999 (equivalent to $4/cr) + $4.5/cr for overages
+        - 500 credits: $1,799 (equivalent to $3.6/cr) + $4.15/cr for overages
+        - 1,000 credits: $3,199 (equivalent to $3.2/cr) + $3.75/cr for overages
+        - 2,000 credits: $4,999 (equivalent to $2.5/cr) + $2.5/cr for overages
     - **Credit rollovers**: Unused credits now roll over for 3 months (previously 2), so you have a full quarter to use them.
 
   As a temporary incentive to encourage you to optimize your spend, Airbyte is offering free overage credits to organizations that upgrade to a higher plan (conditions apply).

--- a/docs/release_notes/cloud/readme.md
+++ b/docs/release_notes/cloud/readme.md
@@ -2,6 +2,12 @@
 
 Airbyte Cloud is updated continuously. You always have the latest features and fixes.
 
+## September 14, 2026
+
+Platform
+
+- Airbyte Cloud has a new Plus plan. Plus is self-serve: choose the number of credits you need each month, and get 15-minute sync schedules, two workspaces, single sign-on, and premium support. Select or change your plan from the new Plan page in Organization settings. A new Standard plan follows on September 21, 2026. Existing Standard organizations that use single sign-on keep it as long as they remain paying customers. For details, see [Airbyte's pricing page](https://airbyte.com/pricing) and [Manage billing and credits](/platform/cloud/managing-airbyte-cloud/manage-credits).
+
 ## September 10, 2026
 
 Platform

--- a/docs/release_notes/cloud/readme.md
+++ b/docs/release_notes/cloud/readme.md
@@ -6,7 +6,7 @@ Airbyte Cloud is updated continuously. You always have the latest features and f
 
 Platform
 
-- Airbyte Cloud has a new Plus plan. Plus is self-serve: choose the number of credits you need each month, and get 15-minute sync schedules, two workspaces, single sign-on, and premium support. Select or change your plan from the new Plan page in Organization settings. A new Standard plan follows on September 21, 2026. Existing Standard organizations that use single sign-on keep it as long as they remain paying customers. For details, see [Airbyte's pricing page](https://airbyte.com/pricing) and [Manage billing and credits](/platform/cloud/managing-airbyte-cloud/manage-credits).
+- Airbyte Cloud has a new Plus plan. Plus is self-serve: choose the number of credits you need each month, and get 15-minute sync schedules, two workspaces, single sign-on, and premium support. Subscribe to Plus, or upgrade to it from Standard, from the new Plan page in Organization settings; downgrading from Plus goes through Sales. A new Standard plan follows on September 21, 2026. Existing Standard organizations that use single sign-on keep it as long as they remain paying customers. For details, see [Airbyte's pricing page](https://airbyte.com/pricing) and [Manage billing and credits](/platform/cloud/managing-airbyte-cloud/manage-credits).
 
 ## September 10, 2026
 

--- a/docs/release_notes/cloud/readme.md
+++ b/docs/release_notes/cloud/readme.md
@@ -6,7 +6,20 @@ Airbyte Cloud is updated continuously. You always have the latest features and f
 
 Platform
 
-- Airbyte Cloud has a new Plus plan. Plus is self-serve: choose the number of credits you need each month, and get 15-minute sync schedules, two workspaces, single sign-on, and premium support. Subscribe to Plus, or upgrade to it from Standard, from the new Plan page in Organization settings; downgrading from Plus goes through Sales. A new Standard plan follows on September 21, 2026. Existing Standard organizations that use single sign-on keep it as long as they remain paying customers. For details, see [Airbyte's pricing page](https://airbyte.com/pricing) and [Manage billing and credits](/platform/cloud/managing-airbyte-cloud/manage-credits).
+- **Airbyte Cloud has a new pricing model** for self-serve plans (Standard and Plus). Pro and Flex are not affected. For many of you, **the price of the Plus plan is significantly cheaper** than the price of the Standard plan. We strongly recommend visiting [Airbyte's pricing page](https://airbyte.com/pricing) to determine the optimal plan for you. New Plus plans are available immediately. The Standard plan switches on September 21. Here's what's changing:
+    - **Standard**: the base price for Standard increases from $10 per month to $20 per month. The number of free credits each month also increases from 4 to 5. The price for additional credits increases from $2.50 to $5.00. Single sign on (SSO) is no longer available on Standard, but if you already use SSO, you may continue doing so as long as you keep your plan.
+    - **Plus**: Multiple new pricing tiers are available. All Plus plans include a much larger allocation of credits, less expensive overage credits, 15-minute sync frequency, two workspaces, mappings (renames only), single sign-on, and premium support. Existing Plus subscribers are being moved from 50 to 100 credits and your plan cost has dropped $50. The following Plus tiers are available:
+        - 40 credits - $189 (equivalent to $4.75/cr) + $5 per credit for overages
+        - 100 credits - $449 (equivalent to $4.5/cr) + $5 per credit for overages
+        - 250 credits - $999 (equivalent to $4/cr) + $4.5 per credit for overages
+        - 500 credits - $1,799 (equivalent to $3.6/cr) + $4.15 per credit for overages
+        - 1,000 credits - $3,199 (equivalent to $3.2/cr) + $3.75 per credit for overages
+        - 2,000 credits - $4,999 (equivalent to $2.5/cr) + $2.5 per credit for overages
+    - **Credit rollovers**: Unused credits now roll over for 3 months (previously 2), so you have a full quarter to use them.
+
+  As a temporary incentive to encourage you to optimize your spend, Airbyte is offering free overage credits to organizations that upgrade to a higher plan (conditions apply).
+
+  To adjust your plan, open Airbyte Cloud and click **Organization settings** > **Plans**. See [Manage billing and credits](/platform/cloud/managing-airbyte-cloud/manage-credits) for more help.
 
 ## September 10, 2026
 

--- a/docusaurus/src/components/ProductInformation.jsx
+++ b/docusaurus/src/components/ProductInformation.jsx
@@ -61,7 +61,7 @@ export const ProductInformation = ({ products }) => {
       </Badge>
       {embedded && <Badge available={true}>Embedded</Badge>}
       <a
-        href="https://airbyte.com/product/features"
+        href="https://airbyte.com/pricing"
         target="_blank"
         className={styles.helpIcon}
       >


### PR DESCRIPTION
## What

Prepares Cloud docs for additional tiers and cleans up some historical things I noticed. Linear: [DOCS-95](https://linear.app/airbyteio/issue/DOCS-95/new-self-serve-plans). Requested by Ian Alton (@ian-at-airbyte).

Per the ticket, evergreen docs stop reproducing prices and feature matrices and point to https://airbyte.com/pricing instead; `products:` metadata is retained.

Plan changes: Standard ↔ Plus is self-serve from Organization settings > Plan; Pro/Flex go through Sales.

## Review guide

1. `docs/platform/cloud/managing-airbyte-cloud/manage-credits.md`
2. `docs/platform/cloud/managing-airbyte-cloud/understand-airbyte-cloud-limits.md`
3. `docs/release_notes/cloud/readme.md`
4. Remaining files are one-line changes.

## User Impact

## Test plan

- markdownlint (`markdownlint-cli2` with `.markdownlint.jsonc`) and Vale (`docusaurus/vale.ini`) on changed files: no new findings beyond a pre-existing `Google.WordList` false positive on "single sign-on".
- `pnpm build` in `docusaurus/` (Node 22) succeeds; no broken links/anchors in changed files.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌

Link to Devin session: https://app.devin.ai/sessions/d8cbf90951684e36b89758a2becc3de4
Open in Devin Desktop: https://app.devin.ai/desktop/session/d8cbf90951684e36b89758a2becc3de4?variant=devin